### PR TITLE
Fix bug 1077879 - Add an HTML view

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source =
     webplatformcompat
 omit =
     tools/client.py
+    tools/download_data.py
     tools/load_spec_data.py
     tools/load_webcompat_data.py
     tools/sample_mdn.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,5 @@ omit =
     tools/load_webcompat_data.py
     tools/sample_mdn.py
     tools/sync_from_api.py
+    tools/upload_data.py
     webplatformcompat/migrations/*.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,13 @@
 branch = True
 
 [report]
-source = webplatformcompat
-omit = webplatformcompat/migrations/*.py
+source =
+    tools
+    webplatformcompat
+omit =
+    tools/client.py
+    tools/load_spec_data.py
+    tools/load_webcompat_data.py
+    tools/sample_mdn.py
+    tools/sync_from_api.py
+    webplatformcompat/migrations/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ docs/_build/*
 data-human.json
 Spec2.txt
 SpecName.txt
+data/*.json
 
 # SQLite databases
 *.sqlite3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include Makefile .coveragerc manage.py
 include requirements.txt requirements.dev.txt
 include Procfile app.json
 
+recursive-include data README.txt
 recursive-include docs Makefile *.gv *.svg conf.py *.rst make.bat
 recursive-include tests *.py
 recursive-include tools *.py

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-all:
 
 coverage:
 	coverage erase
-	coverage run --source webplatformcompat setup.py test
+	coverage run --source webplatformcompat,tools setup.py test
 	coverage report -m
 	coverage html
 	open htmlcov/index.html

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,9 @@ Development
 -----------
 
 :Code:           https://github.com/jwhitlock/web-platform-compat
-:Dev Server:     http://doesitwork-dev.allizom.org
+:Dev Server:     http://doesitwork-dev.allizom.org (based on `webplatform/compatibility-data`_)
+
+                 https://browsercompat.herokuapp.com (based on `jwhitlock/browsercompat-data`_)
 :Issues:         https://bugzilla.mozilla.org/buglist.cgi?quicksearch=compat-data (tracking bug)
 
                  https://github.com/jwhitlock/web-platform-compat/issues?state=open (documentation issues)
@@ -54,3 +56,6 @@ Development
 :Dev Docs:       https://web-platform-compat.readthedocs.org
 :Mailing list:   https://lists.mozilla.org/listinfo/dev-mdn
 :IRC:            irc://irc.mozilla.org/mdndev
+
+.. _`webplatform/compatibility-data`: https://github.com/webplatform/compatibility-data
+.. _`jwhitlock/browsercompat-data`: https://github.com/jwhitlock/browsercompat-data

--- a/data/README.txt
+++ b/data/README.txt
@@ -1,0 +1,1 @@
+This folder contains a copy of the API data.

--- a/data/README.txt
+++ b/data/README.txt
@@ -1,1 +1,3 @@
-This folder contains a copy of the API data.
+This folder is for downloading API data for development purposes.
+You may want to instead use the data at:
+https://github.com/jwhitlock/browsercompat-data

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -39,6 +39,5 @@ django-debug-toolbar==1.2.2
 # Test coverage
 coverage==3.7.1
 docopt==0.6.2
-requests==2.4.3
 PyYAML==3.11
 coveralls==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,6 @@ django-sortedm2m==0.8.1
 
 # Cached instances for Django REST Framework
 drf-cached-instances==0.1.0
+
+# Better HTTP Client for tools
+requests==2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ django-mptt==0.6.1
 django-sortedm2m==0.8.1
 
 # Cached instances for Django REST Framework
-drf-cached-instances==0.1.0
+drf-cached-instances==0.2.0
 
 # Better HTTP Client for tools
 requests==2.4.3

--- a/tools/client.py
+++ b/tools/client.py
@@ -89,7 +89,7 @@ class Client(object):
                 return response.json()
             except:
                 pass
-        return response.content
+        return response.text
 
     def login(self, user, password, next_path='/api/v1/browsers'):
         """Log into the API."""

--- a/tools/client.py
+++ b/tools/client.py
@@ -14,7 +14,7 @@ import logging
 
 import requests
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('tools.client')
 
 
 class APIException(Exception):
@@ -176,15 +176,14 @@ class Client(object):
         # Response is empty, but return it.
         return response
 
-    def get_resources(self, resource_type, logger_name=logger.name, log_at=15):
+    def get_resource_collection(self, resource_type, log_at=15):
         """Get all the resources of a type as a single JSON API response.
 
         Keyword arguments:
         resource_type -- resource name, such as 'browsers'
-        logger_name -- logger name if non-default logger desired
-        log_at -- Every (log_at) seconds, log download progress
+        log_at -- Every (log_at) seconds, log download progress. Set to a
+        negative number to disable.
         """
-        logger = logging.getLogger(logger_name)
         data = None
         next_url = True
         page = 0
@@ -194,7 +193,7 @@ class Client(object):
         while next_url:
             page += 1
             current_time = time()
-            if data and (current_time - last_time) > log_at:
+            if data and log_at >= 0 and (current_time - last_time) > log_at:
                 count = float(len(data[resource_type]))
                 percent = int(100 * (count / total))
                 logger.info(
@@ -244,7 +243,7 @@ if __name__ == "__main__":
     quiet = args.quiet
     console = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = __name__
+    logger_name = 'tools'
     fmat = '%(levelname)s - %(message)s'
     if quiet:
         level = logging.WARNING

--- a/tools/download_data.py
+++ b/tools/download_data.py
@@ -10,8 +10,7 @@ import sys
 
 from client import Client
 
-logger_name = 'download_data'
-logger = logging.getLogger(logger_name)
+logger = logging.getLogger('tools.download_data')
 
 resources = [
     'browsers',
@@ -29,7 +28,7 @@ def download_data(client, base_dir=''):
     counts = {}
     for resource in resources:
         # Get data from API
-        data = client.get_resources(resource, 'download_data')
+        data = client.get_resource_collection(resource)
         logger.info("Downloaded %d %s.", len(data[resource]), resource)
         counts[resource] = len(data[resource])
 
@@ -73,6 +72,7 @@ if __name__ == '__main__':
     console = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter('%(levelname)s - %(message)s')
     fmat = '%(levelname)s - %(message)s'
+    logger_name = 'tools'
     if quiet:
         level = logging.WARNING
     elif verbose:

--- a/tools/download_data.py
+++ b/tools/download_data.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import codecs
+import json
+import logging
+import os.path
+import sys
+
+from client import Client
+
+logger_name = 'download_data'
+logger = logging.getLogger(logger_name)
+
+resources = [
+    'browsers',
+    'versions',
+    'features',
+    'supports',
+    'specifications',
+    'maturities',
+    'sections',
+]
+
+
+def download_data(client, base_dir=''):
+    """Download data from the API"""
+    counts = {}
+    for resource in resources:
+        # Get data from API
+        data = client.get_resources(resource, 'download_data')
+        logger.info("Downloaded %d %s.", len(data[resource]), resource)
+        counts[resource] = len(data[resource])
+
+        # Remove history relations
+        for item in data[resource]:
+            del item['links']['history']
+            del item['links']['history_current']
+        if 'links' in data:
+            del data['links']['%s.history' % resource]
+            del data['links']['%s.history_current' % resource]
+
+        # Write to a file
+        filepath = os.path.join(base_dir, '%s.json' % resource)
+        with codecs.open(filepath, 'w', 'utf8') as f:
+            json.dump(data, f, indent=4, separators=(',', ': '))
+
+    return counts
+
+if __name__ == '__main__':
+    import argparse
+    description = 'Download data from API.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '-a', '--api',
+        help='Base URL of the API (default: http://localhost:8000)',
+        default="http://localhost:8000")
+    parser.add_argument(
+        '-v', '--verbose', action="store_true",
+        help='Print extra debug information')
+    parser.add_argument(
+        '-q', '--quiet', action="store_true",
+        help='Only print warnings')
+    parser.add_argument(
+        '-d', '--data', default='data',
+        help='Output data folder (default: data)')
+    args = parser.parse_args()
+
+    # Setup logging
+    verbose = args.verbose
+    quiet = args.quiet
+    console = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    fmat = '%(levelname)s - %(message)s'
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+        logger_name = ''
+        fmat = '%(name)s - %(levelname)s - %(message)s'
+    else:
+        level = logging.INFO
+    formatter = logging.Formatter(fmat)
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    logger.addHandler(console)
+
+    # Parse arguments
+    api = args.api
+    if api.endswith('/'):
+        api = api[:-1]
+    data = args.data
+    if data.endswith('/'):
+        data = data[:-1]
+    logger.info("Downloading data from %s to %s", api, data)
+
+    # Initialize client
+    client = Client(api)
+
+    # Load data
+    counts = download_data(client, data)
+
+    if counts:
+        logger.info("Download complete.")
+    else:
+        logger.info("No data downloaded.")

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import codecs
 import getpass
 import logging
 import os.path
@@ -12,76 +13,87 @@ import sys
 import requests
 
 from client import Client
+from resources import Collection, CollectionChangeset, Maturity, Specification
 
 try:
     input = raw_input  # Get the Py2 raw_input
 except NameError:
     pass  # We're in Py3
 
-
-logger = logging.getLogger('populate_data')
+logger = logging.getLogger('load_spec_data')
 SPEC2_FILENAME = 'Spec2.txt'
 SPEC2_URL = 'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw'
 SPECNAME_FILENAME = 'SpecName.txt'
 SPECNAME_URL = 'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw'
 
 
-def verify_empty_api(client):
-    """Verify that no data is loaded into this API"""
-    for resource in ('specifications', 'sections', 'maturities'):
-        if client.count(resource) != 0:
-            raise Exception('API already has %s data' % resource)
-
-
 def get_template(filename, url):
     if not os.path.exists(filename):
         logger.info("Downloading " + filename)
         r = requests.get(url)
-        with open(filename, 'wb') as f:
+        with codecs.open(filename, 'wb', 'utf8') as f:
             f.write(r.content)
     else:
         logger.info("Using existing " + filename)
 
-    with open(filename, 'r') as f:
+    with codecs.open(filename, 'r', 'utf8') as f:
         template = f.read()
     return template
 
 
-def load_spec_data(client, specname, spec2):
+def load_spec_data(client, specname, spec2, confirm=None):
     """Load a dictionary of specification data into the API"""
-    verify_empty_api(client)
-    parsed_data = parse_spec_data(specname, spec2)
-    logger.info('Opening changeset...')
-    client.open_changeset()
-    counts = {}
-    try:
-        counts = upload_spec_data(client, parsed_data)
-    finally:
-        logger.info('Closing changeset...')
-        client.close_changeset()
+    api_collection = Collection(client)
+    local_collection = Collection()
+
+    logger.info('Reading existing spec data from API')
+    load_api_spec_data(api_collection)
+    logger.info('Reading spec data from MDN templates')
+    parse_spec_data(specname, spec2, api_collection, local_collection)
+
+    changeset = CollectionChangeset(api_collection, local_collection)
+    delta = changeset.changes
+    if delta['new'] or delta['changed'] or delta['deleted']:
+        logger.info(
+            'Changes detected: %d new, %d changed, %d deleted, %d same.',
+            len(delta['new']), len(delta['changed']), len(delta['deleted']),
+            len(delta['same']))
+        if confirm:
+            confirmed = confirm(client, changeset)
+        else:
+            confirmed = True
+        if not confirmed:
+            return {}
+    else:
+        logger.info('No changes')
+        return {}
+
+    counts = changeset.change_original_collection(logger.name)
     return counts
 
 
-def parse_spec_data(specname, spec2):
-    parsed_data = {
-        'maturities': dict(),
-        'specifications': dict(),
-        'spec_slugs': set(),
-    }
-
-    parse_specname(specname, parsed_data)
-    parse_spec2(spec2, parsed_data)
-    return parsed_data
+def load_api_spec_data(api_collection):
+    api_collection.load_all('maturities')
+    api_collection.load_all('specifications')
 
 
-def parse_specname(specname, parsed_data):
+def parse_spec_data(specname, spec2, api_collection, local_collection):
+    parse_specname(specname, api_collection, local_collection)
+    parse_spec2(spec2, local_collection)
+
+
+def parse_specname(specname, api_collection, local_collection):
     phase = 0
     mdn_key = None
     name = None
     url = None
+    slugs = set([
+        s.slug for s in api_collection.get_resources('specifications')])
     mdn_key_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*{")
     name_re = re.compile(r"\s+name\s*:\s*['\"](.*)['\"],?\s*$")
     url_re = re.compile(r"\s+url\s*:\s*['\"](.*)['\"],?\s*$")
+    api_specs = api_collection.get_resources_by_data_id('specifications')
+
     for line in specname.split('\n'):
         if phase == 0:
             # Looking for start of specList
@@ -105,14 +117,15 @@ def parse_specname(specname, parsed_data):
                 assert name is not None
                 assert url is not None
                 if url.startswith('http'):
-                    slug = unique_slugify(mdn_key, parsed_data['spec_slugs'])
-                    spec_id = mdn_key
-                    parsed_data['specifications'][spec_id] = {
-                        'slug': slug,
-                        'mdn_key': mdn_key,
-                        'name': {'en': name},
-                        'uri': {'en': url},
-                    }
+                    api_spec = api_specs.get(('specifications', mdn_key))
+                    if api_spec:
+                        slug = api_spec.slug
+                    else:
+                        slug = unique_slugify(mdn_key, slugs)
+                    spec = Specification(
+                        id="_" + slug, slug=slug, mdn_key=mdn_key,
+                        name={u'en': name}, uri={u'en': url}, sections=[])
+                    local_collection.add(spec)
                 else:
                     logger.warning(
                         'Discarding specification "%s" with url "%s"',
@@ -128,13 +141,14 @@ def parse_specname(specname, parsed_data):
     assert phase == 2, "SpecName didn't match expected format"
 
 
-def parse_spec2(spec2, parsed_data):
+def parse_spec2(specname, local_collection):
     phase = 0
     key = None
     name = None
     status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
     mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
     name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
+    local_specs = local_collection.get_resources_by_data_id('specifications')
 
     for line in spec2.split('\n'):
         if phase == 0:
@@ -147,9 +161,9 @@ def parse_spec2(spec2, parsed_data):
                 phase = 2
             elif status_re.match(line):
                 spec_key, maturity_key = status_re.match(line).groups()
-                spec = parsed_data['specifications'].get(spec_key.strip())
+                spec = local_specs.get(('specifications', spec_key))
                 if spec:
-                    spec['maturity_id'] = maturity_key.strip()
+                    spec.maturity = maturity_key
                 else:
                     logger.warning(
                         'Skipping maturity for unknown spec "%s"', spec_key)
@@ -173,21 +187,31 @@ def parse_spec2(spec2, parsed_data):
                 if lang == 'en-US':
                     lang = 'en'
                 assert lang not in name
-                name[lang.strip()] = trans.strip().decode('string_escape')
+                text = trans.strip().replace('\\\\', '&#92;')
+                text = text.replace('\\', '').replace('&#92;', '\\')
+                name[lang.strip()] = text
             elif line.startswith('  })'):
                 assert key is not None
                 assert name
-                mat_id = key
-                parsed_data['maturities'][mat_id] = {
-                    'slug': mat_id,
-                    'name': name,
-                }
+                specs = local_collection.filter(
+                    'specifications', maturity=key)
+                if specs:
+                    maturity = Maturity(id=key, slug=key, name=name)
+                    local_collection.add(maturity)
+                else:
+                    logger.warning('Skipping unused maturity "%s"', key)
                 key = None
                 name = None
         elif phase == 4:
             # Not processing rest of file
             pass
     assert phase == 4, "Spec2 didn't match expected format"
+
+    # Remove Specs without maturities
+    immature_specs = local_collection.filter('specifications', maturity=None)
+    for spec in immature_specs:
+        logger.warning('Skipping spec with no maturity "%s"', spec.name['en'])
+        local_collection.remove(spec)
 
 
 def slugify(word, attempt=0):
@@ -219,79 +243,17 @@ def unique_slugify(word, existing):
     return slug
 
 
-def upload_spec_data(client, parsed_data):
-    api_ids = dict(
-        (n, {}) for n in ['maturities', 'specifications'])
-
-    logger.info("Importing specifications...")
-    for specification_id in sorted(parsed_data['specifications'].keys()):
-        upload_specification(client, specification_id, parsed_data, api_ids)
-        if len(api_ids['specifications']) % 100 == 0:
-            logger.info(
-                "Imported %d specifications..." %
-                len(api_ids['specifications']))
-
-    counts = dict((n, len(api_ids[n])) for n in api_ids)
-    return counts
-
-
-def upload_maturity(client, maturity_id, parsed_data, api_ids):
-    """Upload a parsed maturity to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    maturity_id - ID of the maturity in parsed_data['maturities']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if maturity_id not in api_ids['maturities']:
-        maturity = parsed_data['maturities'][maturity_id]
-        data = {
-            "slug": maturity['slug'],
-            "name": maturity['name']
-        }
-        response = client.create('maturities', data)
-        api_id = response['id']
-        api_ids['maturities'][maturity_id] = api_id
-    return api_ids['maturities'][maturity_id]
-
-
-def upload_specification(client, specification_id, parsed_data, api_ids):
-    """Upload a parsed specification to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    specification_id - ID of the specification in parsed_data['specifications']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if specification_id not in api_ids['specifications']:
-        specification = parsed_data['specifications'][specification_id]
-        if 'maturity_id' not in specification:
-            logger.warning(
-                'Not uploading specification "%s", no associated maturity',
-                specification_id)
-            return None
-        maturity_id = specification['maturity_id']
-        maturity_api_id = upload_maturity(
-            client, maturity_id, parsed_data, api_ids)
-        data = {
-            "slug": specification['slug'],
-            "mdn_key": specification['mdn_key'],
-            "name": specification['name'],
-            "uri": specification['uri'],
-            "links": {
-                "maturity": maturity_api_id
-            }
-        }
-        response = client.create('specifications', data)
-        api_id = response['id']
-        api_ids['specifications'][specification_id] = api_id
-    return api_ids['specifications'][specification_id]
+def confirm_changes(client, changeset):
+    while True:
+        choice = input("Make these changes? (Y/N/D for details) ")
+        if choice.upper() == 'Y':
+            return True
+        elif choice.upper() == 'N':
+            return False
+        elif choice.upper() == 'D':
+            print(changeset.summarize())
+        else:
+            print("Please type Y or N or D.")
 
 
 if __name__ == '__main__':
@@ -352,8 +314,23 @@ if __name__ == '__main__':
     # Load data
     specname = get_template(SPECNAME_FILENAME, SPECNAME_URL)
     spec2 = get_template(SPEC2_FILENAME, SPEC2_URL)
-    counts = load_spec_data(client, specname, spec2)
+    counts = load_spec_data(client, specname, spec2, confirm_changes)
 
-    logger.info("Upload complete. Counts:")
-    for name, count in counts.items():
-        logger.info("  %s: %d" % (name, count))
+    if counts:
+        logger.info("Changes complete. Counts:")
+        for resource_type, changes in counts.items():
+            c_new = changes.get('new', 0)
+            c_deleted = changes.get('deleted', 0)
+            c_changed = changes.get('changed', 0)
+            c_text = []
+            if c_new:
+                c_text.append("%d new" % c_new)
+            if c_deleted:
+                c_text.append("%d deleted" % c_deleted)
+            if c_changed:
+                c_text.append("%d changed" % c_changed)
+            if c_text:
+                logger.info("  %s: %s" % (
+                    resource_type.title(), ', '.join(c_text)))
+    else:
+        logger.info("No data uploaded.")

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -20,7 +20,7 @@ try:
 except NameError:
     pass  # We're in Py3
 
-logger = logging.getLogger('load_spec_data')
+logger = logging.getLogger('tools.load_spec_data')
 SPEC2_FILENAME = 'Spec2.txt'
 SPEC2_URL = 'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw'
 SPECNAME_FILENAME = 'SpecName.txt'
@@ -68,7 +68,7 @@ def load_spec_data(client, specname, spec2, confirm=None):
         logger.info('No changes')
         return {}
 
-    counts = changeset.change_original_collection(logger.name)
+    counts = changeset.change_original_collection()
     return counts
 
 
@@ -280,7 +280,7 @@ if __name__ == '__main__':
     quiet = args.quiet
     console = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'populate_data'
+    logger_name = 'tools'
     fmat = '%(levelname)s - %(message)s'
     if quiet:
         level = logging.WARNING

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -25,7 +25,7 @@ except NameError:
     pass  # We're in Py3
 
 
-logger = logging.getLogger('load_webcompat_data')
+logger = logging.getLogger('tools.load_webcompat_data')
 COMPAT_DATA_FILENAME = "data-human.json"
 COMPAT_DATA_URL = (
     "https://raw.githubusercontent.com/webplatform/compatibility-data"
@@ -97,7 +97,7 @@ def load_compat_data(client, compat_data, all_data=False, confirm=None):
         logger.info('No changes')
         return {}
 
-    counts = changeset.change_original_collection(logger.name)
+    counts = changeset.change_original_collection()
     return counts
 
 
@@ -373,7 +373,7 @@ if __name__ == '__main__':
     quiet = args.quiet
     console = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'populate_data'
+    logger_name = 'tools'
     fmat = '%(levelname)s - %(message)s'
     if quiet:
         level = logging.WARNING

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 
 from cgi import escape
+from collections import defaultdict
+import codecs
 import getpass
 import json
 import logging
@@ -14,6 +16,8 @@ import sys
 import requests
 
 from client import Client
+from resources import (
+    Collection, CollectionChangeset, Browser, Version, Feature, Support)
 
 try:
     input = raw_input  # Get the Py2 raw_input
@@ -21,7 +25,7 @@ except NameError:
     pass  # We're in Py3
 
 
-logger = logging.getLogger('populate_data')
+logger = logging.getLogger('load_webcompat_data')
 COMPAT_DATA_FILENAME = "data-human.json"
 COMPAT_DATA_URL = (
     "https://raw.githubusercontent.com/webplatform/compatibility-data"
@@ -46,58 +50,77 @@ known_browsers = [
 version_re = re.compile("^[.\d]+$")
 
 
-def verify_empty_api(client):
-    """Verify that no data is loaded into this API"""
-    for resource in ('browsers', 'versions', 'features', 'supports'):
-        if client.count(resource) != 0:
-            raise Exception('API already has %s data' % resource)
-
-
 def get_compat_data(filename, url):
     if not os.path.exists(filename):
         logger.info("Downloading " + filename)
         r = requests.get(url)
-        with open(filename, 'wb') as f:
+        with codecs.open(filename, 'wb', 'utf8') as f:
             f.write(r.content)
     else:
         logger.info("Using existing " + filename)
 
-    with open(filename, 'r') as f:
+    with codecs.open(filename, 'r', 'utf8') as f:
         compat_data = json.load(f)
     return compat_data
 
 
-def load_compat_data(client, compat_data, all_data=False):
+def load_compat_data(client, compat_data, all_data=False, confirm=None):
     """Load a dictionary of compatiblity data into the API"""
-    verify_empty_api(client)
-    parsed_data = parse_compat_data(compat_data)
-    logger.info('Opening changeset...')
-    client.open_changeset()
-    counts = {}
-    try:
-        if all_data:
-            counts = upload_compat_data(client, parsed_data)
+    api_collection = Collection(client)
+    local_collection = Collection()
+
+    logger.info('Reading existing feature data from API')
+    load_api_feature_data(api_collection)
+    logger.info('Loading feature data from webplatform repository')
+    parse_compat_data(compat_data, local_collection)
+
+    if not all_data:
+        logger.info('Selecting subset of data')
+        select_subset(local_collection)
+
+    logger.info('Looking for changes...')
+    changeset = CollectionChangeset(api_collection, local_collection)
+    delta = changeset.changes
+
+    if delta['new'] or delta['changed'] or delta['deleted']:
+        logger.info(
+            'Changes detected: %d new, %d changed, %d deleted, %d same.',
+            len(delta['new']), len(delta['changed']), len(delta['deleted']),
+            len(delta['same']))
+        if confirm:
+            confirmed = confirm(client, changeset)
         else:
-            counts = upload_subset_compat_data(client, parsed_data)
-    finally:
-        logger.info('Closing changeset...')
-        client.close_changeset()
+            confirmed = True
+        if not confirmed:
+            return {}
+    else:
+        logger.info('No changes')
+        return {}
+
+    counts = changeset.change_original_collection(logger.name)
     return counts
 
 
-def parse_compat_data(compat_data):
-    parsed_data = {
-        'browsers': dict(),
-        'features': dict(),
-        'feature_slugs': set(),
-        'versions': dict(),
-        'supports': dict(),
-    }
+def load_api_feature_data(api_collection):
+    api_collection.load_all('browsers')
+    api_collection.load_all('versions')
+    api_collection.load_all('features')
+    api_collection.load_all('supports')
 
+
+def parse_compat_data(compat_data, local_collection):
+    local_collection.feature_slugs = set()
     for key, value in compat_data['data'].items():
-        parse_compat_data_item(key, value, parsed_data)
+        parse_compat_data_item(key, value, local_collection)
 
-    return parsed_data
+    # Populate the sorted versions
+    browser_versions = defaultdict(list)
+    for version in local_collection.get_resources_by_data_id(
+            'versions').values():
+        browser_versions[version.browser.id].append(version)
+    for browser_id, versions in browser_versions.items():
+        browser = local_collection.get('browsers', browser_id)
+        browser.versions = sorted([v.id.id for v in versions])
 
 
 def slugify(word, attempt=0):
@@ -116,7 +139,8 @@ def slugify(word, attempt=0):
         suffix = str(attempt)
     else:
         suffix = ""
-    return slugged[slice(50 - len(suffix))] + suffix
+    with_suffix = slugged[slice(50 - len(suffix))] + suffix
+    return with_suffix.decode('utf-8')
 
 
 def unique_slugify(word, existing):
@@ -129,7 +153,7 @@ def unique_slugify(word, existing):
     return slug
 
 
-def parse_compat_data_item(key, item, parsed_data):
+def parse_compat_data_item(key, item, local_collection):
     browser_conversions = {
         "IE Phone": "IE Mobile",
         "Chrome for Andriod": "Chrome for Android",
@@ -147,26 +171,26 @@ def parse_compat_data_item(key, item, parsed_data):
         'notes',
     ]
     support_map = {
-        'y': 'yes',
-        'u': 'unknown',
-        'x': 'prefix',
-        'n': 'no',
-        'a': 'unknown',
+        'y': u'yes',
+        'u': u'unknown',
+        'x': u'prefix',
+        'n': u'no',
+        'a': u'unknown',
     }
     support_prefix = {
-        'Chrome': '-webkit',
-        'Safari': '-webkit',
-        'Android': '-webkit',
-        'Chrome Mobile': '-webkit',
-        'Chrome for Android': '-webkit',
-        'BlackBerry': '-webkit',
-        'Firefox': '-moz',
-        'Firefox OS': '-moz',
-        'Safari Mobile': '-moz',
-        'Firefox Mobile': '-moz',
-        'Opera': '-o',
-        'Opera Mobile': '-o',
-        'Internet Explorer': '-ms',
+        'Chrome': u'-webkit',
+        'Safari': u'-webkit',
+        'Android': u'-webkit',
+        'Chrome Mobile': u'-webkit',
+        'Chrome for Android': u'-webkit',
+        'BlackBerry': u'-webkit',
+        'Firefox': u'-moz',
+        'Firefox OS': u'-moz',
+        'Safari Mobile': u'-moz',
+        'Firefox Mobile': u'-moz',
+        'Opera': u'-o',
+        'Opera Mobile': u'-o',
+        'Internet Explorer': u'-ms',
     }
 
     if "breadcrumb" in item:
@@ -183,42 +207,41 @@ def parse_compat_data_item(key, item, parsed_data):
         for bit in path_bits:
             last_feature_id = feature_id
             feature_id += (bit,)
-            if feature_id not in parsed_data['features']:
-                parsed_data['features'][feature_id] = {
-                    'slug': unique_slugify(
-                        '-'.join(feature_id), parsed_data['feature_slugs']),
-                    'mdn_uri': None,
-                    'name': {'en': bit},
-                    'parent_id': last_feature_id,
-                }
+            if not local_collection.get('features', feature_id):
+                slug = unique_slugify(
+                    '-'.join(feature_id), local_collection.feature_slugs)
+                local_collection.add(Feature(
+                    id=feature_id, slug=slug, name={u'en': bit},
+                    experimental=False, obsolete=False, stable=True,
+                    standardized=True, mdn_uri=None,
+                    parent=last_feature_id or None))
         parent_feature_id = feature_id
-        parsed_data['features'][parent_feature_id]['mdn_uri'] = url
+        parent_feature = local_collection.get('features', parent_feature_id)
+        parent_feature.mdn_uri = {u'en': url}
 
         for env, rows in item['contents'].items():
             assert env in ('desktop', 'mobile')
             for feature, columns in rows.items():
                 # Add feature
                 feature_id = parent_feature_id + (feature,)
-                if feature_id not in parsed_data['features']:
-                    parsed_data['features'][feature_id] = {
-                        'slug': unique_slugify(
-                            '-'.join(feature_id),
-                            parsed_data['feature_slugs']),
-                        'mdn_uri': url,
-                        'name': {'en': escape(feature)},
-                        'parent_id': parent_feature_id,
-                    }
+                if not local_collection.get('features', feature_id):
+                    slug = unique_slugify(
+                        '-'.join(feature_id), local_collection.feature_slugs)
+                    local_collection.add(Feature(
+                        id=feature_id, slug=slug,
+                        mdn_uri={u'en': url}, name={u'en': escape(feature)},
+                        experimental=False, obsolete=False, stable=True,
+                        standardized=True, parent=parent_feature_id))
 
                 # Add browser
                 for raw_browser, versions in columns.items():
                     browser = browser_conversions.get(raw_browser, raw_browser)
                     assert browser in known_browsers, raw_browser
                     browser_id = known_browsers.index(browser)
-                    if browser_id not in parsed_data['browsers']:
-                        parsed_data['browsers'][browser_id] = {
-                            'slug': slugify(browser),
-                            'name': browser,
-                        }
+                    if not local_collection.get('browsers', browser_id):
+                        local_collection.add(Browser(
+                            id=browser_id, slug=slugify(browser),
+                            name={u'en': browser}, note=None))
 
                     version_note = versions.get('notes', {})
                     for raw_version, raw_support in versions.items():
@@ -227,22 +250,28 @@ def parse_compat_data_item(key, item, parsed_data):
                             continue
                         version, version_id = convert_version(
                             browser_id, raw_version)
-                        if version_id not in parsed_data['versions']:
-                            parsed_data['versions'][version_id] = {
-                                'version': version,
-                            }
+                        if not local_collection.get('versions', version_id):
+                            local_collection.add(Version(
+                                id=version_id, version=version,
+                                browser=browser_id, note=None,
+                                release_day=None, release_notes_uri=None,
+                                retirement_day=None, status=u'unknown'))
 
                         # Add support
                         support_id = (version_id, feature_id)
-                        if support_id not in parsed_data['supports']:
+                        if not local_collection.get('supports', support_id):
                             notes = []
-
-                            support = support_map[raw_support[0]]
-                            if support == 'prefix':
-                                support = 'yes'
-                                prefix = support_prefix[browser]
-                            else:
-                                prefix = None
+                            obj = Support(
+                                id=support_id, feature=feature_id,
+                                version=version_id, alternate_name=None,
+                                alternate_mandatory=False,
+                                default_config=None, footnote=None,
+                                note=None, prefix=None, prefix_mandatory=False,
+                                protected=False, requires_config=None)
+                            obj.support = support_map[raw_support[0]]
+                            if obj.support == 'prefix':
+                                obj.support = 'yes'
+                                obj.prefix = support_prefix[browser]
 
                             if len(raw_support) > 1:
                                 notes.append(
@@ -251,26 +280,24 @@ def parse_compat_data_item(key, item, parsed_data):
                             for item in version_note.items():
                                 notes.append('%s: %s' % item)
 
-                            data = {'support': support}
                             if notes:
                                 joined = '<br>'.join(escape(n) for n in notes)
-                                data['note'] = {'en': joined}
-                            if prefix:
-                                data['prefix'] = prefix
-                                data['prefix_mandatory'] = True
-                            parsed_data['supports'][support_id] = data
+                                obj.note = {'en': joined}
+                            if obj.prefix:
+                                obj.prefix_mandatory = True
+                            local_collection.add(obj)
     else:
         for subkey, subitem in item.items():
-            parse_compat_data_item(subkey, subitem, parsed_data)
+            parse_compat_data_item(subkey, subitem, local_collection)
 
 
 def convert_version(browser_id, raw_version):
-    version = "" if raw_version == "?" else raw_version
     if raw_version == '?':
-        version = ""
+        version = None
     else:
         version = raw_version
-    if version == "":
+    if not version:
+        version = None
         version_id = (browser_id,)
     else:
         assert version_re.match(version), raw_version
@@ -283,191 +310,40 @@ def convert_version(browser_id, raw_version):
     return version, version_id
 
 
-def upload_compat_data(client, parsed_data):
-    api_ids = dict(
-        (n, {}) for n in ['browsers', 'versions', 'features', 'supports'])
-    logger.info("Importing browsers...")
-    for browser_id in sorted(parsed_data['browsers'].keys()):
-        upload_browser(client, browser_id, parsed_data, api_ids)
-        if len(api_ids['browsers']) % 100 == 0:
-            logger.info("Imported %d browsers..." % len(api_ids['browsers']))
+def select_subset(local_collection):
+    """Discard all but a subset of features and supports"""
+    # Select features to keep
+    keep_feature_ids = set()
+    for feature in local_collection.get_resources('features'):
+        if feature.mdn_uri and 'Web/CSS/c' in feature.mdn_uri['en']:
+            keep_feature_ids.add(feature.id.id)
+            parent = feature.parent.get()
+            while parent:
+                keep_feature_ids.add(parent.id.id)
+                parent = parent.parent.get()
 
-    logger.info("Importing versions...")
-    for version_id in sorted(parsed_data['versions'].keys()):
-        upload_version(client, version_id, parsed_data, api_ids)
-        if len(api_ids['versions']) % 100 == 0:
-            logger.info("Imported %d versions..." % len(api_ids['versions']))
+    # Discard unrelated supports
+    for support in local_collection.get_resources('supports')[:]:
+        if support.feature.id not in keep_feature_ids:
+            local_collection.remove(support)
 
-    logger.info("Importing features...")
-    for feature_id in sorted(parsed_data['features'].keys()):
-        upload_feature(client, feature_id, parsed_data, api_ids)
-        if len(api_ids['features']) % 100 == 0:
-            logger.info("Imported %d features..." % len(api_ids['features']))
-
-    logger.info("Importing supports...")
-    for support_id in sorted(parsed_data['supports'].keys()):
-        upload_support(client, support_id, parsed_data, api_ids)
-        if len(api_ids['supports']) % 100 == 0:
-            logger.info("Imported %d supports..." % len(api_ids['supports']))
-
-    counts = dict((n, len(api_ids[n])) for n in api_ids)
-    return counts
+    # Discard unrelated features
+    for feature in local_collection.get_resources('features')[:]:
+        if feature.id.id not in keep_feature_ids:
+            local_collection.remove(feature)
 
 
-def upload_subset_compat_data(client, parsed_data):
-    api_ids = dict(
-        (n, {}) for n in ['browsers', 'versions', 'features', 'supports'])
-
-    # Load all browsers, versions because no Support instances yet
-    logger.info("Importing browsers...")
-    for browser_id in sorted(parsed_data['browsers'].keys()):
-        upload_browser(client, browser_id, parsed_data, api_ids)
-        if len(api_ids['browsers']) % 100 == 0:
-            logger.info("Imported %d browsers..." % len(api_ids['browsers']))
-
-    logger.info("Importing versions...")
-    for version_id in sorted(parsed_data['versions'].keys()):
-        upload_version(client, version_id, parsed_data, api_ids)
-        if len(api_ids['versions']) % 100 == 0:
-            logger.info("Imported %d versions..." % len(api_ids['versions']))
-
-    logger.info("Importing CSS features starting with c...")
-    for feature_id in sorted(parsed_data['features'].keys()):
-        feature = parsed_data['features'][feature_id]
-        mdn_uri = feature['mdn_uri']
-        if mdn_uri and 'Web/CSS/c' in mdn_uri:
-            upload_feature(client, feature_id, parsed_data, api_ids)
-            if len(api_ids['features']) % 100 == 0:
-                logger.info(
-                    "Imported %d features..." % len(api_ids['features']))
-
-    logger.info("Import related supports...")
-    for support_id in sorted(parsed_data['supports'].keys()):
-        feature_id = support_id[1]
-        if feature_id in api_ids['features']:
-            upload_support(client, support_id, parsed_data, api_ids)
-            if len(api_ids['supports']) % 100 == 0:
-                logger.info(
-                    "Imported %d supports..." % len(api_ids['supports']))
-
-    counts = dict((n, len(api_ids[n])) for n in api_ids)
-    return counts
-
-
-def upload_browser(client, browser_id, parsed_data, api_ids):
-    """Upload a parsed browser to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    browser_id - ID of the browser in parsed_data['browsers']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if browser_id not in api_ids['browsers']:
-        browser = parsed_data['browsers'][browser_id]
-        data = {
-            "slug": browser['slug'],
-            "name": {'en': browser['name']}
-        }
-        response = client.create('browsers', data)
-        api_id = response['id']
-        api_ids['browsers'][browser_id] = api_id
-    return api_ids['browsers'][browser_id]
-
-
-def upload_version(client, version_id, parsed_data, api_ids):
-    """Upload a parsed version to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    version_id - ID of the version in parsed_data['versions']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if version_id not in api_ids['versions']:
-        version = parsed_data['versions'][version_id]
-        browser_id = version_id[0]
-        browser_api_id = upload_browser(
-            client, browser_id, parsed_data, api_ids)
-        data = {
-            "version": version['version'],
-            "status": version.get('status', 'unknown'),
-            "links": {
-                "browser": browser_api_id
-            }
-        }
-        response = client.create('versions', data)
-        api_id = response['id']
-        api_ids['versions'][version_id] = api_id
-    return api_ids['versions'][version_id]
-
-
-def upload_feature(client, feature_id, parsed_data, api_ids):
-    """Upload a parsed feature to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    feature_id - ID of the feature in parsed_data['features']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if feature_id == ():
-        return None
-    elif feature_id not in api_ids['features']:
-        feature = parsed_data['features'][feature_id]
-        parent_id = feature["parent_id"]
-        parent_api_id = upload_feature(
-            client, parent_id, parsed_data, api_ids)
-        data = {
-            "slug": feature["slug"],
-            "name": feature["name"],
-            "links": {
-                "parent": parent_api_id,
-            }
-        }
-        if feature.get("mdn_uri"):
-            data['mdn_uri'] = {'en': feature['mdn_uri']}
-        response = client.create('features', data)
-        api_id = response['id']
-        api_ids['features'][feature_id] = api_id
-    return api_ids['features'][feature_id]
-
-
-def upload_support(client, support_id, parsed_data, api_ids):
-    """Upload a parsed support to the API
-
-    Keyword Arguments:
-    client - authenticated client to use for uploads
-    support_id - ID of the support in parsed_data['supports']
-    parsed_data - dictionary of all the parsed data
-    api_ids - dictionary of IDs of uploaded instances
-
-    Return is the ID generated by the API
-    """
-    if support_id not in api_ids['supports']:
-        support = parsed_data['supports'][support_id]
-        version_id, feature_id = support_id
-        version_api_id = upload_version(
-            client, version_id, parsed_data, api_ids)
-        feature_api_id = upload_feature(
-            client, feature_id, parsed_data, api_ids)
-        data = {
-            "support": support['support'],
-            "links": {
-                "version": version_api_id,
-                "feature": feature_api_id,
-            },
-        }
-        response = client.create('supports', data)
-        api_id = response['id']
-        api_ids['supports'][support_id] = api_id
-    return api_ids['supports'][support_id]
+def confirm_changes(client, changeset):
+    while True:
+        choice = input("Make these changes? (Y/N/D for details) ")
+        if choice.upper() == 'Y':
+            return True
+        elif choice.upper() == 'N':
+            return False
+        elif choice.upper() == 'D':
+            print(changeset.summarize())
+        else:
+            print("Please type Y or N or D.")
 
 
 if __name__ == '__main__':
@@ -533,8 +409,24 @@ if __name__ == '__main__':
 
     # Load data
     compat_data = get_compat_data(COMPAT_DATA_FILENAME, COMPAT_DATA_URL)
-    counts = load_compat_data(client, compat_data, all_data=all_data)
+    counts = load_compat_data(
+        client, compat_data, all_data=all_data, confirm=confirm_changes)
 
-    logger.info("Upload complete. Counts:")
-    for name, count in counts.items():
-        logger.info("  %s: %d" % (name, count))
+    if counts:
+        logger.info("Changes complete. Counts:")
+        for resource_type, changes in counts.items():
+            c_new = changes.get('new', 0)
+            c_deleted = changes.get('deleted', 0)
+            c_changed = changes.get('changed', 0)
+            c_text = []
+            if c_new:
+                c_text.append("%d new" % c_new)
+            if c_deleted:
+                c_text.append("%d deleted" % c_deleted)
+            if c_changed:
+                c_text.append("%d changed" % c_changed)
+            if c_text:
+                logger.info("  %s: %s" % (
+                    resource_type.title(), ', '.join(c_text)))
+    else:
+        logger.info("No data uploaded.")

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -1,0 +1,700 @@
+"""Classes for working with web-platform-compat resources."""
+
+from collections import defaultdict, OrderedDict
+from difflib import Differ
+from itertools import chain
+from logging import getLogger
+from pprint import pformat
+
+
+class Link(object):
+    """Proxy for database IDs in a collection."""
+
+    class NoId(object):
+        """Placeholder for local objects without an ID."""
+        pass
+
+    def __init__(self, collection, linked_type, linked_id=None):
+        self.collection = collection
+        self.linked_type = linked_type
+        if linked_id is None:
+            self.linked_id = Link.NoId()
+        else:
+            self.linked_id = linked_id
+
+    def get(self):
+        assert self.collection
+        return self.collection.get(self.linked_type, self.id)
+
+    @property
+    def id(self):
+        if self.collection:
+            return self.collection.get_override_id(
+                self.linked_type, self.linked_id)
+        elif isinstance(self.linked_id, Link.NoId):
+            return None
+        else:
+            return self.linked_id
+
+    def set_collection(self, collection):
+        assert (not self.collection) or (self.collection == collection)
+        self.collection = collection
+
+
+class LinkList(object):
+    """Proxy for a set of database IDs in a collection."""
+    def __init__(self, collection, linked_type, linked_ids):
+        self.collection = collection
+        self.links = [
+            Link(collection, linked_type, lid) for lid in linked_ids]
+
+    @property
+    def ids(self):
+        return [l.id for l in self.links]
+
+    def set_collection(self, collection):
+        assert (not self.collection) or (self.collection == collection)
+        self.collection = collection
+        for item in self.links:
+            item.set_collection(collection)
+
+
+class Resource(object):
+    """A web-platform-compat resource.
+
+    Derived classes *must* define two class-level attributes:
+    _resource_type - the name of the API resource, such as 'browsers'
+    _id_data - a tuple of property names (own properties or properties on
+        related resources) that would identify a resource if IDs differed.
+
+    Derived classes may define other class-level attributes:
+    _writeable_property_fields - a tuple of property names that can be set
+        by a client.
+    _readonly_property_fields - a tuple of property names that may be on a
+        resource but can't / shouldn't be written by a client.
+    _writeable_link_fields - a dictionary of link names to the pair
+        (linked resource type, True if to-many field), writable by client
+    _readonly_link_fields - a dictionary of link names to link properties,
+        that can't / shouldn't be written by the client.
+    """
+
+    # A writable linked field has many elements and is a sort field
+    SORTED = "SORTED"
+
+    def __init__(self, collection=None, **properties):
+        """Initialize a Resource.
+
+        Keyword Arguments:
+        -- collection - A collection to associate with this Resource
+
+        Additional keyword arguments will be assigned as fields.
+        """
+        # Avoid _getattr__ infinite loop
+        object.__setattr__(self, '_fields', set())
+        object.__setattr__(self, '_property_fields', set())
+        object.__setattr__(self, '_link_fields', {})
+
+        self._data = {}
+        self._collection = collection
+
+        assert hasattr(self, '_resource_type'), "Must set _resource_type"
+        assert hasattr(self, '_id_data'), "Must set _unique index"
+        assert tuple(sorted(self._id_data)) == tuple(self._id_data), \
+            "_id_data must be sorted"
+
+        # Get field definitions, setting to default if not defined
+        wprops = getattr(self, '_writeable_property_fields', ())
+        self._writeable_property_fields = wprops
+        rprops = getattr(self, '_readonly_property_fields', ())
+        self._readonly_property_fields = rprops
+        wlinks = getattr(self, '_writeable_link_fields', {})
+        self._writeable_link_fields = wlinks
+        rlinks = getattr(self, '_readonly_link_fields', {})
+        self._readonly_link_fields = rlinks
+
+        # Load fields
+        for field in chain(wprops, rprops):
+            assert field not in self._fields, 'Duplicate field "%s"' % field
+            self._fields.add(field)
+            self._property_fields.add(field)
+        link_fields = chain(
+            [('id', (self._resource_type, False))],
+            wlinks.items(), rlinks.items())
+        for field, attributes in link_fields:
+            assert field not in self._fields, 'Duplicate field "%s"' % field
+            self._fields.add(field)
+            self._link_fields[field] = attributes
+        assert self._fields, "Must set fields"
+
+        # Load properties
+        for key, val in properties.items():
+            assert key in self._fields
+            setattr(self, key, val)
+
+    def __getattr__(self, name):
+        """Retrieve resource properties and links."""
+        if name in self._fields:
+            if self._data:
+                return self._data.get(name, None)
+            else:
+                return None
+        raise AttributeError
+
+    def __setattr__(self, name, value):
+        """Set resource properties and links."""
+        if name in self._property_fields:
+            # Directly assign properties
+            self._data[name] = value
+        elif name in self._link_fields:
+            # Convert to Link or LinkList before assigning links
+            resource_type, is_list = self._link_fields[name]
+            link_class = LinkList if is_list else Link
+            link_value = link_class(self._collection, resource_type, value)
+            self._data[name] = link_value
+        else:
+            object.__setattr__(self, name, value)
+
+    def from_json_api(self, json_api):
+        """Load from a JSON API representation.
+
+        Both readable and writable fields are read, and additional items,
+        such links, metadata, and unknown fields, are discarded.
+        """
+        assert self._resource_type in json_api.keys(), "Unexpected json_api"
+
+        items = chain(
+            json_api[self._resource_type].items(),
+            json_api[self._resource_type].get('links', {}).items()
+        )
+        for key, value in items:
+            if key in self._fields:
+                assert key not in self._data
+                setattr(self, key, value)
+
+    def get_data_id(self):
+        data_id = [self._resource_type]
+        for name in self._id_data:
+            # Load properties in related resources
+            resource = self
+            orig_name = name
+            while '.' in name:
+                link_name, name = name.split('.', 1)
+                assert link_name in resource._link_fields
+                link = getattr(resource, link_name)
+                resource = self._collection.get(
+                    link.linked_type, link.id)
+                assert resource, \
+                    'When looking up "%s", could not find ID "%s" in %s.' % (
+                        orig_name, link.id, link.linked_type)
+            data_item = getattr(resource, name)
+            if data_item is None:
+                data_id.append('')
+            else:
+                data_id.append(data_item)
+        return tuple(data_id)
+
+    def set_collection(self, collection):
+        assert (self._collection is None) or (self._collection == collection)
+        self._collection = collection
+        for field_name in self._link_fields:
+            field = getattr(self, field_name)
+            if field:
+                field.set_collection(collection)
+
+    def to_json_api(self, with_sorted=False):
+        """Export to JSON API representation.
+
+        Only writable properties and links are included.
+
+        Keyword Arguments:
+        with_sorted -- If False (default), then writable links representing a
+        sort order are excluded.
+        """
+        assert self._data, "No data to export"
+
+        data = {}
+        for field in self._writeable_property_fields:
+            if field in self._data:
+                data[field] = self._data[field]
+        for field, attr in self._writeable_link_fields.items():
+            is_sorted = attr[1] == Resource.SORTED
+            if not with_sorted and is_sorted:
+                continue
+            if field in self._data:
+                link = self._data[field]
+                if isinstance(link, Link):
+                    value = link.id
+                else:
+                    assert isinstance(link, LinkList)
+                    value = link.ids
+                data.setdefault('links', {})[field] = value
+        return {self._resource_type: data}
+
+
+class Browser(Resource):
+    _resource_type = 'browsers'
+    _writeable_property_fields = ('slug', 'name', 'note')
+    _writeable_link_fields = {
+        'versions': ('versions', Resource.SORTED),
+    }
+    _readonly_link_fields = {
+        'history': ('historical_browsers', True),
+        'history_current': ('historical_browsers', False),
+    }
+    _id_data = ('slug',)
+
+
+class Version(Resource):
+    _resource_type = 'versions'
+    _writeable_property_fields = (
+        'version', 'release_day', 'retirement_day', 'status',
+        'release_notes_uri', 'note')
+    _writeable_link_fields = {
+        'browser': ('browsers', False),
+    }
+    _readonly_link_fields = {
+        'supports': ('supports', True),
+        'history': ('historical_versions', True),
+        'history_current': ('historical_versions', False),
+    }
+    _id_data = ('browser.slug', 'version')
+
+
+class Feature(Resource):
+    _resource_type = 'features'
+    _writeable_property_fields = (
+        'slug', 'mdn_uri', 'experimental', 'standardized', 'stable',
+        'obsolete', 'name')
+    _writeable_link_fields = {
+        'parent': ('features', False),
+    }
+    _readonly_link_fields = {
+        'children': ('features', True),
+        'sections': ('sections', True),
+        'supports': ('supports', True),
+        'history': ('historical_features', True),
+        'history_current': ('historical_features', False),
+    }
+    _id_data = ('slug',)
+
+
+class Support(Resource):
+    _resource_type = 'supports'
+    _writeable_property_fields = (
+        'support', 'prefix', 'prefix_mandatory', 'alternate_name',
+        'alternate_name_mandatory', 'requires_config', 'default_config',
+        'protected', 'note', 'footnote')
+    _writeable_link_fields = {
+        'version': ('versions', False),
+        'feature': ('features', False),
+    }
+    _readonly_link_fields = {
+        'history': ('historical_supports', True),
+        'history_current': ('historical_supports', False),
+    }
+    _id_data = ('feature.slug', 'version.browser.slug', 'version.version')
+
+
+class Specification(Resource):
+    _resource_type = 'specifications'
+    _writeable_property_fields = ('slug', 'mdn_key', 'name', 'uri')
+    _writeable_link_fields = {
+        'maturity': ('maturities', False),
+        'sections': ('sections', Resource.SORTED),
+    }
+    _readonly_link_fields = {
+        'history': ('historical_specifications', True),
+        'history_current': ('historical_specifications', False),
+    }
+    _id_data = ('mdn_key',)
+
+
+class Section(Resource):
+    _resource_type = 'sections'
+    _writeable_property_fields = ('number', 'name', 'subpath', 'note')
+    _writeable_link_fields = {
+        'specification': ('specifications', False),
+    }
+    _readonly_link_fields = {
+        'features': ('features', True),
+        'history': ('historical_sections', True),
+        'history_current': ('historical_sections', False),
+    }
+    _id_data = ('number_en', 'specification.mdn_key')
+
+    @property
+    def number_en(self):
+        return self.number['en']
+
+
+class Maturity(Resource):
+    _resource_type = 'maturities'
+    _writeable_property_fields = ('slug', 'name')
+    _readonly_link_fields = {
+        'specifications': ('specifications', True),
+        'history': ('historical_maturities', True),
+        'history_current': ('historical_maturities', False)
+    }
+    _id_data = ('slug',)
+
+
+class Collection(object):
+
+    """A collection of resources."""
+
+    resource_by_type = {
+        'browsers': Browser,
+        'versions': Version,
+        'features': Feature,
+        'supports': Support,
+        'sections': Section,
+        'specifications': Specification,
+        'maturities': Maturity,
+    }
+
+    def __init__(self, client=None):
+        """Initialize a Collection.
+
+        Keyword Arguments:
+        client -- API Client that can read and write resources
+        """
+        self._repository = {}
+        self._override_ids = {}
+        self._id_index = {}
+        self.client = client
+
+    def add(self, resource):
+        """Add a resource to the collection."""
+        resource_type = resource._resource_type
+        self._repository.setdefault(resource_type, []).append(resource)
+
+        # Set collection
+        resource.set_collection(self)
+
+        # Add to ID index
+        resources = self._id_index.setdefault(resource_type, {})
+        id_link = resource.id
+        if id_link:
+            resource_id = id_link.id
+            assert resource_id not in resources
+            resources[resource_id] = resource
+
+    def get(self, resource_type, db_id):
+        """Get a resource by database ID."""
+        return self._id_index.get(resource_type, {}).get(db_id, None)
+
+    def get_all_by_data_id(self):
+        """Get all items with a unique index lookup."""
+        indexed = {}
+        for resource_type in self._repository.keys():
+            indexed.update(self.get_resources_by_data_id(resource_type))
+        return indexed
+
+    def get_override_id(self, resource_type, resource_id):
+        """Get an overriden resource ID."""
+        return self._override_ids.get(
+            resource_type, {}).get(resource_id, resource_id)
+
+    def get_resources(self, resource_type):
+        """Get all the resources of the resource type."""
+        return self._repository.get(resource_type, [])
+
+    def get_resources_by_data_id(self, resource_type):
+        """Get a dict mapping a resource by its unique index"""
+        resources = {}
+        for item in self.get_resources(resource_type):
+            data_id = item.get_data_id()
+            assert data_id not in resources
+            resources[data_id] = item
+        return resources
+
+    def filter(self, resource_type, **properties):
+        """Get all resources matching the property values."""
+        assert properties
+        resources = self.get_resources(resource_type)
+        matches = []
+        for resource in resources:
+            match = True
+            for name, value in properties.items():
+                if name in resource._link_fields:
+                    link = getattr(resource, name)
+                    if link:
+                        match &= (link.id == value)
+                    else:
+                        match &= (value is None)
+                else:
+                    match &= (getattr(resource, name) == value)
+            if match:
+                matches.append(resource)
+        return matches
+
+    def load_all(self, resource_type):
+        """Read all API data into the collection."""
+        assert self.client, 'load_all requires an API Client'
+        resource_class = self.resource_by_type[resource_type]
+        original_count = len(self._repository.get(resource_type, []))
+        next_url = True
+        page = 0
+        while next_url:
+            page += 1
+            params = {'page': page}
+            response = self.client.request('GET', resource_type, params=params)
+            assert resource_type in response
+            for item in response[resource_type]:
+                resource = resource_class(collection=self)
+                resource.from_json_api({resource_type: item})
+                self.add(resource)
+            next_url = response['meta']['pagination'][resource_type]['next']
+        done_count = len(self._repository.get(resource_type, []))
+        return done_count - original_count
+
+    def override_ids_to_match(self, sync_collection):
+        """Change IDs to match another collection."""
+        self._override_ids = {}
+
+        # Find all matching items with the other collection
+        sync_index = sync_collection.get_all_by_data_id()
+        my_index = self.get_all_by_data_id()
+        sync_keys = set(sync_index.keys())
+        my_keys = set(my_index.keys())
+        match_keys = sorted(sync_keys & my_keys)
+
+        # Map IDs in self collection to IDs in sync_collection
+        new_ids = {}
+        for key in match_keys:
+            sync_item = sync_index[key]
+            sync_id = sync_item.id.linked_id
+            assert sync_id
+            self_item = my_index[key]
+            if not self_item.id:
+                self_item.id = Link(self, self_item._resource_type, None)
+                self_item.id.linked_id = self_item.id
+            self_id = self_item.id.linked_id
+            assert self_id
+            resource_type = key[0]
+            new_ids.setdefault(resource_type, {})[self_id] = sync_id
+
+        # Update the IDs
+        for key, item in my_index.items():
+            resource_type = key[0]
+
+            # Update the item ID
+            if item.id:
+                assert item.id.linked_id
+                old_id = item.id.linked_id
+                new_id = new_ids.get(resource_type, {}).get(old_id, old_id)
+                self._override_ids.setdefault(
+                    resource_type, {})[old_id] = new_id
+
+        # Redo ID index
+        self._id_index = {}
+        for resource_type, resources in self._repository.items():
+            self._id_index[resource_type] = {}
+            for resource in resources:
+                id_link = resource.id
+                if id_link:
+                    resource_id = id_link.id
+                    assert resource_id not in resources
+                    self._id_index[resource_type][resource_id] = resource
+
+    def remove(self, resource):
+        """Remove a resource from the collection."""
+        resource_type = resource._resource_type
+        self._repository[resource_type].remove(resource)
+        id_link = resource.id
+        if id_link:
+            resource_id = id_link.id
+            del self._id_index[resource_type][resource_id]
+
+
+class CollectionChangeset(object):
+    """Determine changes from one collection to another."""
+
+    def __init__(self, original_collection, new_collection):
+        """Initialize a CollectionChangeset.
+
+        Keyword Arguments:
+        original_collection -- The original Collection
+        new_collection -- The new Collection
+        client -- A Client that can access the original Collection
+        """
+        self.original_collection = original_collection
+        self.new_collection = new_collection
+        assert self.original_collection.client, \
+            'original_collection must have a client.'
+
+        self.new_collection.override_ids_to_match(self.original_collection)
+
+        self._populate_changes()
+
+    def _populate_changes(self):
+        """Populate the changes attribute."""
+        orig_index = self.original_collection.get_all_by_data_id()
+        my_index = self.new_collection.get_all_by_data_id()
+        orig_keys = set(orig_index.keys())
+        my_keys = set(my_index.keys())
+
+        self.changes = {
+            "new": OrderedDict(),
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict(),
+        }
+
+        def new_resource_keys_with_dependencies(resource, new_keys):
+            """Get dependencies needed to add a resource"""
+            my_key = resource.get_data_id()
+            if my_key not in new_keys:
+                return []
+            else:
+                new_keys.remove(my_key)
+
+            keys = []
+            sorted_links = []
+            for link_name, lmeta in resource._writeable_link_fields.items():
+                is_sorted = (lmeta[1] == Resource.SORTED)
+                link_attr = getattr(item, link_name, None)
+
+                if isinstance(link_attr, Link):
+                    links = [link_attr]
+                elif isinstance(link_attr, LinkList):
+                    links = link_attr.links
+                else:
+                    assert link_attr is None
+                    links = []
+
+                for link in links:
+                    linked = link.get()
+                    link_keys = (
+                        new_resource_keys_with_dependencies(linked, new_keys))
+                    if is_sorted:
+                        sorted_links.extend(link_keys)
+                    else:
+                        keys.extend(link_keys)
+            keys.append(my_key)
+            keys.extend(sorted_links)
+            return keys
+
+        # Handle new items with sort fields
+        new_keys = sorted(my_keys - orig_keys)
+        for k in new_keys[:]:
+            item = my_index[k]
+            has_sorted = False
+            for _, link_type in item._writeable_link_fields.values():
+                if link_type == Resource.SORTED:
+                    has_sorted = True
+            if has_sorted:
+                item_keys = new_resource_keys_with_dependencies(item, new_keys)
+                for ik in item_keys:
+                    self.changes['new'][ik] = my_index[ik]
+
+        # Sort remaining new items
+        for k in new_keys[:]:
+            item = my_index[k]
+            item_keys = new_resource_keys_with_dependencies(item, new_keys)
+            for ik in item_keys:
+                self.changes['new'][ik] = my_index[ik]
+
+        # Collect deleted items
+        del_keys = orig_keys - my_keys
+        for k in sorted(del_keys):
+            self.changes['deleted'][k] = orig_index[k]
+
+        # Sort same / changed items
+        match_keys = orig_keys & my_keys
+        for k in sorted(match_keys):
+            orig_item = orig_index[k]
+            orig_json = orig_item.to_json_api(with_sorted=True)
+            my_item = my_index[k]
+            my_json = my_item.to_json_api(with_sorted=True)
+            if orig_json == my_json:
+                self.changes['same'][k] = my_item
+            else:
+                my_item._original = orig_item
+                self.changes['changed'][k] = my_item
+
+    def change_original_collection(self, logger_name=__name__, checkpoint=100):
+        """Commit changes to the original Collection
+
+        Keyword Arguments:
+        -- logger_name - The name of the logger that gets progress message
+        -- checkpoint - Item count between progress messages
+
+        Return is a dictionary of resource types to a dictionary of actions
+        ('new', 'deleted', 'changed') and the counts of those actions.
+        """
+        logger = getLogger(logger_name)
+        client = self.original_collection.client
+
+        logger.info('Opening changeset...')
+        client.open_changeset()
+
+        counts = defaultdict(lambda: defaultdict(int))
+        try:
+            for item in self.changes['new'].values():
+                resource_type = item._resource_type
+                json_api = item.to_json_api()
+                response = client.create(
+                    resource_type, json_api[resource_type])
+                if not item.id:
+                    item.id = Link.NoId()
+                old_id = item.id.linked_id
+                new_id = response['id']
+                item._collection._override_ids.setdefault(
+                    resource_type, {})[old_id] = new_id
+                counts[resource_type]['new'] += 1
+                count = counts[resource_type]['new']
+                if (count % checkpoint == 0):  # pragma nocover
+                    logger.info("Imported %d %s" % (count, resource_type))
+
+            for item in self.changes['deleted'].values():
+                resource_type = item._resource_type
+                client.delete(resource_type, item.id.id)
+                item._collection.remove(item)
+                counts[resource_type]['deleted'] += 1
+                count = counts[resource_type]['deleted']
+                if (count % checkpoint == 0):  # pragma nocover
+                    logger.info("Deleted %d %s" % (count, resource_type))
+
+            for item in self.changes['changed'].values():
+                json_api = item.to_json_api()
+                resource_type = item._resource_type
+                client.update(
+                    resource_type, item.id.id, json_api[resource_type])
+                counts[resource_type]['changed'] += 1
+                count = counts[resource_type]['changed']
+                if (count % checkpoint == 0):  # pragma nocover
+                    logger.info("Imported %d %s" % (count, resource_type))
+        finally:
+            logger.info('Closing changeset...')
+            client.close_changeset()
+        return counts
+
+    def summarize(self):
+        """Get human-friendly summary of changes."""
+        out = []
+        client = self.original_collection.client
+
+        # Summarize new resources
+        for item in self.changes['new'].values():
+            resource_type = item._resource_type
+            new_json = pformat(item.to_json_api())
+            out.append("New %s:\n%s" % (resource_type, new_json))
+
+        # Summarize deleted resources
+        for item in self.changes['deleted'].values():
+            url = client.url(item._resource_type, item.id.id)
+            old_json = pformat(item.to_json_api())
+            out.append("Deleted %s:\n%s" % (url, old_json))
+
+        # Summarize changed resources
+        for item in self.changes['changed'].values():
+            url = client.url(item._resource_type, item.id.id)
+            orig_item = item._original
+            orig_json = pformat(orig_item.to_json_api())
+            new_json = pformat(item.to_json_api())
+            diff = ''.join(Differ().compare(
+                orig_json.splitlines(1), new_json.splitlines(1)))
+            out.append("Changed: %s:\n%s" % (url, diff))
+
+        return '\n'.join(out)

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -273,10 +273,10 @@ class Feature(Resource):
         'obsolete', 'name')
     _writeable_link_fields = {
         'parent': ('features', False),
+        'sections': ('sections', True),
     }
     _readonly_link_fields = {
         'children': ('features', True),
-        'sections': ('sections', True),
         'supports': ('supports', True),
         'history': ('historical_features', True),
         'history_current': ('historical_features', False),

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -459,9 +459,9 @@ class TestCollection(TestCase):
         versions = self.col.filter('versions', browser=None)
         self.assertEqual([version2], versions)
 
-    def test_load_all_with_next(self):
-        self.col.client = mock.Mock(spec_set=['request'])
-        self.col.client.request.side_effect = [{
+    def test_load_all(self):
+        self.col.client = mock.Mock(spec_set=['get_resource_collection'])
+        self.col.client.get_resource_collection.return_value = {
             "browsers": [{
                 "id": "1",
                 "slug": "chrome",
@@ -482,38 +482,7 @@ class TestCollection(TestCase):
                     "history_current": "2",
                     "versions": ["40", "41", "42"],
                 }
-            }],
-            "links": {
-                "browsers.history": {
-                    "href": (
-                        "http://example.com/api/v1/historical_browsers/"
-                        "{browsers.history}"),
-                    "type": "historical_browsers"
-                },
-                "browsers.history_current": {
-                    "href": (
-                        "http://example.com/api/v1/historical_browsers/"
-                        "{browsers.history_current}"),
-                    "type": "historical_browsers"
-                },
-                "browsers.versions": {
-                    "href": (
-                        "http://example.com/api/v1/versions/"
-                        "{browsers.versions}"),
-                    "type": "versions"
-                }
-            },
-            "meta": {
-                "pagination": {
-                    "browsers": {
-                        "previous": None,
-                        "next": "http://example.com/api/v1/browsers?page=2",
-                        "count": 3
-                    }
-                }
-            }
-        }, {
-            "browsers": [{
+            }, {
                 "id": "3",
                 "slug": "internet_explorer",
                 "name": {"en": "Internet Explorer"},
@@ -547,15 +516,13 @@ class TestCollection(TestCase):
             "meta": {
                 "pagination": {
                     "browsers": {
-                        "previous": (
-                            "http://example.com/api/v1/browsers?page=1"),
+                        "previous": None,
                         "next": None,
                         "count": 3
                     }
                 }
             }
-
-        }]
+        }
         count = self.col.load_all('browsers')
         self.assertEqual(3, count)
 

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Tests for `web-platform-compat` fields module."""
+from __future__ import unicode_literals
 from unittest import TestCase as BaseTestCase
 
 from collections import OrderedDict
 import mock
-import six
 
 from tools.client import Client
 from tools.resources import (
@@ -760,9 +760,20 @@ class TestCollectionChangeset(TestCase):
         _, cc = self.setup_new()
         expected = """\
 New browsers:
-{'browsers': {'slug': 'chrome'}}
+{
+  "browsers": {
+    "slug": "chrome"
+  }
+}
 New versions:
-{'versions': {'links': {'browser': '_chrome'}, 'version': '2.0'}}"""
+{
+  "versions": {
+    "version": "2.0",
+    "links": {
+      "browser": "_chrome"
+    }
+  }
+}"""
         self.assertEqual(expected, cc.summarize())
 
     def setup_new_with_dependencies(self):
@@ -832,15 +843,47 @@ New versions:
         _, cc = self.setup_new_with_dependencies()
         expected = """\
 New features:
-{'features': {'slug': 'parent'}}
+{
+  "features": {
+    "slug": "parent"
+  }
+}
 New features:
-{'features': {'links': {'parent': 'parent'}, 'slug': 'child1'}}
+{
+  "features": {
+    "slug": "child1",
+    "links": {
+      "parent": "parent"
+    }
+  }
+}
 New features:
-{'features': {'links': {'parent': 'parent'}, 'slug': 'child2'}}
+{
+  "features": {
+    "slug": "child2",
+    "links": {
+      "parent": "parent"
+    }
+  }
+}
 New features:
-{'features': {'links': {'parent': 'parent'}, 'slug': 'child3'}}
+{
+  "features": {
+    "slug": "child3",
+    "links": {
+      "parent": "parent"
+    }
+  }
+}
 New features:
-{'features': {'links': {'parent': 'child2'}, 'slug': 'grandchild'}}"""
+{
+  "features": {
+    "slug": "grandchild",
+    "links": {
+      "parent": "child2"
+    }
+  }
+}"""
         self.assertEqual(expected, cc.summarize())
 
     def setup_deleted(self):
@@ -892,9 +935,20 @@ New features:
         _, cc = self.setup_deleted()
         expected = """\
 Deleted http://example.com/api/v1/browsers/_chrome:
-{'browsers': {'slug': 'chrome'}}
+{
+  "browsers": {
+    "slug": "chrome"
+  }
+}
 Deleted http://example.com/api/v1/versions/_chrome_2:
-{'versions': {'links': {'browser': '_chrome'}, 'version': '2.0'}}"""
+{
+  "versions": {
+    "version": "2.0",
+    "links": {
+      "browser": "_chrome"
+    }
+  }
+}"""
         self.assertEqual(expected, cc.summarize())
 
     def setup_matched(self):
@@ -907,7 +961,9 @@ Deleted http://example.com/api/v1/versions/_chrome_2:
         browser_same = Browser(id='_chrome', slug='chrome')
         version_diff = Version(
             id='_version', version='2.0', browser='_chrome',
-            note={'en': 'Second Version', 'es': 'Segunda Versión'})
+            note=OrderedDict((
+                ('en', 'Second Version'),
+                ('es', 'Segunda Versión'))))
         self.new_col.add(version_diff)
         self.new_col.add(browser_same)
         resources = (version, browser_same, version_diff)
@@ -955,23 +1011,22 @@ Deleted http://example.com/api/v1/versions/_chrome_2:
 
     def test_summary_matched_items(self):
         _, cc = self.setup_matched()
-        if six.PY3:  # pragma nocover
-            expected = """\
+        expected = """\
 Changed: http://example.com/api/v1/versions/1:
-  {'versions': {'links': {'browser': '1'},
--               'note': {'en': 'Second Version'},
-+               'note': {'en': 'Second Version', 'es': 'Segunda Versión'},
-?                                              +++++++++++++++++++++++++
-                'version': '2.0'}}"""
-        else:  # pragma nocover
-            expected = """\
-Changed: http://example.com/api/v1/versions/1:
-  {'versions': {'links': {'browser': '1'},
--               'note': {'en': 'Second Version'},
-?                                              -
-+               'note': {'en': 'Second Version',
-+                        'es': 'Segunda Versi\\xc3\\xb3n'},
-                'version': '2.0'}}"""
+  {
+    "versions": {
+      "version": "2.0",
+      "note": {
+-       "en": "Second Version"
++       "en": "Second Version",
+?                             +
++       "es": "Segunda Versi\\u00f3n"
+      },
+      "links": {
+        "browser": "1"
+      }
+    }
+  }"""
         self.assertEqual(expected, cc.summarize())
 
     def test_new_browser_with_ordered_versions(self):

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -1,0 +1,1030 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for `web-platform-compat` fields module."""
+from unittest import TestCase as BaseTestCase
+
+from collections import OrderedDict
+import mock
+import six
+
+from tools.client import Client
+from tools.resources import (
+    Browser, Collection, CollectionChangeset, Feature, Maturity, Section,
+    Specification, Support, Version, Link, LinkList)
+
+
+class TestCase(BaseTestCase):
+    maxDiff = None
+
+
+class TestLink(TestCase):
+
+    """Test the Link resource."""
+
+    def test_link_without_collection(self):
+        link = Link(None, 'browsers', '1')
+        self.assertEqual(link.id, '1')
+
+    def test_link_without_collection_or_id(self):
+        link = Link(None, 'browsers')
+        self.assertEqual(link.id, None)
+
+    def test_link_with_collection(self):
+        collection = Collection()
+        link = Link(collection, 'browsers', '1')
+        self.assertEqual(link.id, '1')
+        collection._override_ids = {'browsers': {'1': '_browser1'}}
+        self.assertEqual(link.id, '_browser1')
+
+
+class TestBrowser(TestCase):
+
+    """Test the Browser resource, and general Resource functions."""
+
+    def test_load_at_init(self):
+        browser = Browser(slug='browser')
+        self.assertEqual('browser', browser.slug)
+
+    def test_load_by_attribute(self):
+        browser = Browser()
+        browser.id = "6"
+        self.assertIsInstance(browser.id, Link)
+        self.assertEqual("6", browser.id.id)
+
+    def test_missing_attribute(self):
+        raised = False
+        browser = Browser()
+        try:
+            browser.missing_attribute
+        except AttributeError:
+            raised = True
+        self.assertTrue(raised)
+
+    def test_from_json_api(self):
+        rep = {
+            "browsers": {
+                "id": "1",
+                "slug": "chrome",
+                "name": {"en": "Chrome"},
+                "note": None,
+                "links": {
+                    "history": ["1"],
+                    "history_current": "1",
+                    "versions": ["1"],
+                }
+            },
+            "links": {
+                "browsers.history": {
+                    "href": (
+                        "http://example.com/api/v1/historical_browsers/"
+                        "{browsers.history}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.history_current": {
+                    "href": (
+                        "http://localhost:8000/api/v1/historical_browsers/"
+                        "{browsers.history_current}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.versions": {
+                    "href": (
+                        "http://localhost:8000/api/v1/versions/"
+                        "{browsers.versions}"),
+                    "type": "versions"
+                }
+            }
+        }
+        browser = Browser()
+        self.assertIsNone(browser.id)
+        self.assertIsNone(browser.slug)
+        self.assertIsNone(browser.name)
+        self.assertIsNone(browser.note)
+        self.assertIsNone(browser.history)
+        self.assertIsNone(browser.history_current)
+        self.assertIsNone(browser.versions)
+
+        browser.from_json_api(rep)
+        self.assertIsInstance(browser.id, Link)
+        self.assertEqual("1", browser.id.id)
+        self.assertEqual("chrome", browser.slug)
+        self.assertEqual({'en': 'Chrome'}, browser.name)
+        self.assertIsNone(browser.note)
+        self.assertIsInstance(browser.history, LinkList)
+        self.assertEqual(["1"], browser.history.ids)
+        self.assertIsInstance(browser.history_current, Link)
+        self.assertEqual("1", browser.history_current.id)
+        self.assertIsInstance(browser.versions, LinkList)
+        self.assertEqual(["1"], browser.versions.ids)
+
+    def test_get_data_id(self):
+        browser = Browser(slug='firefox')
+        self.assertEqual(('browsers', 'firefox'), browser.get_data_id())
+
+    def test_set_collection(self):
+        browser = Browser(slug='firefox', versions=['1.0', '2.0'])
+        self.assertIsNone(browser._collection)
+        self.assertIsNone(browser.versions.links[0].collection)
+
+        collection = Collection()
+        browser.set_collection(collection)
+        self.assertEqual(collection, browser._collection)
+        self.assertEqual(collection, browser.versions.links[0].collection)
+
+    def test_to_json_api_simple(self):
+        browser = Browser()
+        browser.name = {'en': 'Browser'}
+        expected = {
+            "browsers": {
+                "name": {'en': 'Browser'}
+            }
+        }
+        actual = browser.to_json_api()
+        self.assertEqual(expected, actual)
+
+    def test_to_json_api_complex(self):
+        browser = Browser(
+            id="1", slug="chrome", name={"en": "Chrome"}, history=["1"],
+            history_current="1", versions=["1"])
+        expected = {
+            "browsers": {
+                "slug": "chrome",
+                "name": {"en": "Chrome"},
+            }
+        }
+        actual = browser.to_json_api()
+        self.assertEqual(expected, actual)
+
+    def test_to_json_api_complex_with_sorted(self):
+        browser = Browser(
+            id="1", slug="chrome", name={"en": "Chrome"}, history=["1"],
+            history_current="1", versions=["1"])
+        expected = {
+            "browsers": {
+                "slug": "chrome",
+                "name": {"en": "Chrome"},
+                "links": {"versions": ["1"]},
+            }
+        }
+        actual = browser.to_json_api(True)
+        self.assertEqual(expected, actual)
+
+
+class TestVersion(TestCase):
+    def test_load_by_json(self):
+        rep = {
+            "versions": {
+                "id": "2",
+                "version": "0.2",
+                "release_day": None,
+                "retirement_day": None,
+                "status": "unknown",
+                "release_notes_uri": None,
+                "note": None,
+                "order": 1,
+                "links": {
+                    "browser": "1",
+                    "supports": [
+                        "1120", "1119", "1118", "1117", "1116", "1115", "1114",
+                        "1113", "1112", "1111", "1110", "1109",
+                    ],
+                    "history": ["2"],
+                    "history_current": "2"
+                }
+            },
+        }
+        version = Version()
+        self.assertIsNone(version.id)
+        self.assertIsNone(version.version)
+        self.assertIsNone(version.release_day)
+        self.assertIsNone(version.retirement_day)
+        self.assertIsNone(version.status)
+        self.assertIsNone(version.release_notes_uri)
+        self.assertIsNone(version.note)
+        self.assertIsNone(version.supports)
+        self.assertIsNone(version.history)
+        self.assertIsNone(version.history_current)
+
+        version.from_json_api(rep)
+        self.assertIsInstance(version.id, Link)
+        self.assertEqual("2", version.id.id)
+        self.assertEqual("0.2", version.version)
+        self.assertIsNone(version.release_day)
+        self.assertIsNone(version.retirement_day)
+        self.assertEqual('unknown', version.status)
+        self.assertIsNone(version.release_notes_uri)
+        self.assertIsNone(version.note)
+        self.assertIsInstance(version.supports, LinkList)
+        self.assertEqual(
+            ['1120', '1119', '1118', '1117', '1116', '1115', '1114', '1113',
+             '1112', '1111', '1110', '1109'],
+            version.supports.ids)
+        self.assertIsInstance(version.history_current, Link)
+        self.assertEqual("2", version.history_current.id)
+        self.assertIsInstance(version.history, LinkList)
+        self.assertEqual(["2"], version.history.ids)
+
+    def test_get_data_id(self):
+        version = Version(id="254", version="0.2", browser="2")
+        browser = Browser(id="2", slug="the_browser")
+        collection = Collection()
+        collection.add(version)
+        collection.add(browser)
+        self.assertEqual(
+            ('versions', 'the_browser', '0.2'), version.get_data_id())
+
+    def test_get_data_id_null_version(self):
+        version = Version(id="254", version=None, browser="2")
+        browser = Browser(id="2", slug="the_browser")
+        collection = Collection()
+        collection.add(version)
+        collection.add(browser)
+        self.assertEqual(
+            ('versions', 'the_browser', ''), version.get_data_id())
+
+    def test_to_json(self):
+        version = Version(
+            id="2", version="0.2", status="unknown", supports=["1120", "1119"],
+            browser="2")
+        expected = {
+            "versions": {
+                "version": "0.2",
+                "status": "unknown",
+                "links": {
+                    "browser": "2"
+                }
+            }
+        }
+        self.assertEqual(expected, version.to_json_api())
+
+
+class TestFeature(TestCase):
+    def test_to_json_no_parent(self):
+        feature = Feature(id="1", slug="web", name={"en": "Web"})
+        expected = {
+            "features": {
+                "slug": "web",
+                "name": {"en": "Web"},
+            }
+        }
+        self.assertEqual(expected, feature.to_json_api())
+
+
+class TestSupport(TestCase):
+    def test_to_json(self):
+        support = Support(
+            support="unknown", version="_version", feature="_feature")
+        expected = {
+            "supports": {
+                "support": "unknown",
+                "links": {
+                    "version": "_version",
+                    "feature": "_feature",
+                }}}
+        self.assertEqual(expected, support.to_json_api())
+
+
+class TestSpecification(TestCase):
+    def test_to_json(self):
+        spec = Specification(
+            slug="css1", mdn_key='CSS1', name={'en': 'CSS Level&nbsp;1'},
+            uri={'en': "http://www.w3.org/TR/CSS1/"}, maturity="1",
+            sections=["2"])
+        expected = {
+            "specifications": {
+                'slug': 'css1',
+                'mdn_key': 'CSS1',
+                "name": {"en": "CSS Level&nbsp;1"},
+                "uri": {"en": "http://www.w3.org/TR/CSS1/"},
+                "links": {
+                    "maturity": "1",
+                },
+            },
+        }
+        self.assertEqual(expected, spec.to_json_api())
+
+    def test_to_json_with_sorted(self):
+        spec = Specification(
+            slug="css1", mdn_key='CSS1', name={'en': 'CSS Level&nbsp;1'},
+            uri={'en': "http://www.w3.org/TR/CSS1/"}, maturity="1",
+            sections=["2"])
+        expected = {
+            "specifications": {
+                'slug': 'css1',
+                'mdn_key': 'CSS1',
+                "name": {"en": "CSS Level&nbsp;1"},
+                "uri": {"en": "http://www.w3.org/TR/CSS1/"},
+                "links": {
+                    "maturity": "1",
+                    "sections": ["2"],
+                },
+            },
+        }
+        self.assertEqual(expected, spec.to_json_api(True))
+
+
+class TestSection(TestCase):
+    def test_to_json(self):
+        section = Section(
+            number={'en': '1.2.3'}, name={'en': 'Section Foo'},
+            subpath={'en': '/foo'}, specification='_spec')
+        expected = {
+            "sections": {
+                "number": {'en': '1.2.3'},
+                "name": {'en': 'Section Foo'},
+                "subpath": {'en': '/foo'},
+                "links": {
+                    "specification": "_spec",
+                }}}
+        self.assertEqual(expected, section.to_json_api())
+
+
+class TestMaturity(TestCase):
+    def test_to_json(self):
+        maturity = Maturity(
+            id="_mat", slug="REC", name={'en': 'Recommendation'})
+        expected = {
+            "maturities": {
+                "slug": "REC",
+                "name": {'en': 'Recommendation'},
+            }}
+        self.assertEqual(expected, maturity.to_json_api())
+
+
+class TestCollection(TestCase):
+    def setUp(self):
+        self.col = Collection()
+
+    def test_get_resources(self):
+        browser = Browser(slug='firefox')
+        self.col.add(browser)
+        browsers = self.col.get_resources('browsers')
+        self.assertEqual([browser], browsers)
+
+    def test_get_resources_empty(self):
+        browsers = self.col.get_resources('browsers')
+        self.assertEqual([], browsers)
+
+    def test_get_resources_by_data_id(self):
+        browser = Browser(id='1', slug='firefox')
+        version = Version(version='1.0', browser='1')
+        self.col.add(browser)
+        self.col.add(version)
+        versions = self.col.get_resources_by_data_id('versions')
+        self.assertEqual({('versions', 'firefox', '1.0'): version}, versions)
+        browsers = self.col.get_resources_by_data_id('browsers')
+        self.assertEqual({('browsers', 'firefox'): browser}, browsers)
+
+    def test_get_all_by_data_id(self):
+        browser = Browser(id='1', slug='chrome')
+        self.col.add(browser)
+        version = Version(id='2', version='1.0', browser='1')
+        self.col.add(version)
+        feature = Feature(id='3', slug='the-feature')
+        self.col.add(feature)
+        support = Support(id='4', feature='3', version='2')
+        self.col.add(support)
+        maturity = Maturity(id='5', slug='REC')
+        self.col.add(maturity)
+        specification = Specification(
+            id='6', slug='css1', mdn_key='CSS1', maturity='5')
+        self.col.add(specification)
+        section = Section(id='7', number={'en': '5.6.1'}, specification='6')
+        self.col.add(section)
+
+        index = self.col.get_all_by_data_id()
+        expected = {
+            ('browsers', 'chrome'): browser,
+            ('versions', 'chrome', '1.0'): version,
+            ('features', 'the-feature'): feature,
+            ('supports', 'the-feature', 'chrome', '1.0'): support,
+            ('maturities', 'REC'): maturity,
+            ('specifications', 'CSS1'): specification,
+            ('sections', '5.6.1', 'CSS1'): section,
+        }
+        self.assertEqual(expected, index)
+
+    def test_filter_by_property(self):
+        browser = Browser(id='_firefox', slug='firefox')
+        version1 = Version(version='1.0', browser='_firefox')
+        version2 = Version(version='2.0', browser='_firefox')
+        self.col.add(browser)
+        self.col.add(version1)
+        self.col.add(version2)
+        versions = self.col.filter('versions', version='1.0')
+        self.assertEqual([version1], versions)
+
+    def test_filter_link(self):
+        browser = Browser(id='_firefox', slug='firefox')
+        version1 = Version(version=None, browser='_firefox')
+        version2 = Version(version='1.0', browser='_firefox')
+        self.col.add(browser)
+        self.col.add(version1)
+        self.col.add(version2)
+        versions = self.col.filter('versions', browser='_firefox')
+        self.assertEqual(2, len(versions))
+        self.assertTrue(version1 in versions)
+        self.assertTrue(version2 in versions)
+
+    def test_filter_link_is_none(self):
+        browser = Browser(id='_firefox', slug='firefox')
+        version1 = Version(version=None, browser='_firefox')
+        version2 = Version(version='1.0')
+        self.col.add(browser)
+        self.col.add(version1)
+        self.col.add(version2)
+        versions = self.col.filter('versions', browser=None)
+        self.assertEqual([version2], versions)
+
+    def test_load_all_with_next(self):
+        self.col.client = mock.Mock(spec_set=['request'])
+        self.col.client.request.side_effect = [{
+            "browsers": [{
+                "id": "1",
+                "slug": "chrome",
+                "name": {"en": "Chrome"},
+                "note": None,
+                "links": {
+                    "history": ["1"],
+                    "history_current": "1",
+                    "versions": ["1", "2"],
+                }
+            }, {
+                "id": "2",
+                "slug": "firefox",
+                "name": {"en": "Firefox"},
+                "note": None,
+                "links": {
+                    "history": ["2"],
+                    "history_current": "2",
+                    "versions": ["40", "41", "42"],
+                }
+            }],
+            "links": {
+                "browsers.history": {
+                    "href": (
+                        "http://example.com/api/v1/historical_browsers/"
+                        "{browsers.history}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.history_current": {
+                    "href": (
+                        "http://example.com/api/v1/historical_browsers/"
+                        "{browsers.history_current}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.versions": {
+                    "href": (
+                        "http://example.com/api/v1/versions/"
+                        "{browsers.versions}"),
+                    "type": "versions"
+                }
+            },
+            "meta": {
+                "pagination": {
+                    "browsers": {
+                        "previous": None,
+                        "next": "http://example.com/api/v1/browsers?page=2",
+                        "count": 3
+                    }
+                }
+            }
+        }, {
+            "browsers": [{
+                "id": "3",
+                "slug": "internet_explorer",
+                "name": {"en": "Internet Explorer"},
+                "note": None,
+                "links": {
+                    "history": ["3"],
+                    "history_current": "3",
+                    "versions": ["70", "71", "72"],
+                },
+            }],
+            "links": {
+                "browsers.history": {
+                    "href": (
+                        "http://example.com/api/v1/historical_browsers/"
+                        "{browsers.history}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.history_current": {
+                    "href": (
+                        "http://example.com/api/v1/historical_browsers/"
+                        "{browsers.history_current}"),
+                    "type": "historical_browsers"
+                },
+                "browsers.versions": {
+                    "href": (
+                        "http://example.com/api/v1/versions/"
+                        "{browsers.versions}"),
+                    "type": "versions"
+                }
+            },
+            "meta": {
+                "pagination": {
+                    "browsers": {
+                        "previous": (
+                            "http://example.com/api/v1/browsers?page=1"),
+                        "next": None,
+                        "count": 3
+                    }
+                }
+            }
+
+        }]
+        count = self.col.load_all('browsers')
+        self.assertEqual(3, count)
+
+    def test_override_ids_to_match(self):
+        # Setup collection resources
+        browser = Browser(
+            id='_chrome', slug='chrome', versions=['_version'])
+        version = Version(
+            id='_version', version='1.0', browser='_chrome')
+        feature = Feature(id='_feature', slug='the-feature')
+        support = Support(
+            id='_support', feature='_feature', version='_version')
+        maturity = Maturity(id='_maturity', slug='REC')
+        specification = Specification(
+            id='_spec', slug='css1', mdn_key='CSS1', maturity='_maturity')
+        section = Section(
+            id='_section', number={'en': '5.6.1'}, specification='_spec')
+        self.col.add(browser)
+        self.col.add(version)
+        self.col.add(feature)
+        self.col.add(support)
+        self.col.add(maturity)
+        self.col.add(specification)
+        self.col.add(section)
+
+        # JSON API representation changes
+        expected = {
+            "versions": {
+                "version": "1.0",
+                "links": {
+                    "browser": "_chrome",
+                },
+            }
+        }
+        self.assertEqual(expected, version.to_json_api())
+
+        # Setup other collection with different IDs
+        sync_browser = Browser(id='1', slug='chrome')
+        sync_version = Version(id='2', version='1.0', browser='1')
+        sync_feature = Feature(id='3', slug='the-feature')
+        sync_support = Support(id='4', feature='3', version='2')
+        sync_maturity = Maturity(id='5', slug='REC')
+        sync_specification = Specification(
+            id='6', slug='css1', mdn_key='CSS1', maturity='5')
+        sync_section = Section(
+            id='7', number={'en': '5.6.1'}, specification='6')
+        sync_collection = Collection()
+        sync_collection.add(sync_browser)
+        sync_collection.add(sync_version)
+        sync_collection.add(sync_feature)
+        sync_collection.add(sync_support)
+        sync_collection.add(sync_maturity)
+        sync_collection.add(sync_specification)
+        sync_collection.add(sync_section)
+
+        # Lookup is by local ID
+        self.assertEqual(browser, self.col.get('browsers', '_chrome'))
+        self.assertEqual(None, self.col.get('browsers', '1'))
+
+        # Synchronize IDs to the other collection
+        self.col.override_ids_to_match(sync_collection)
+
+        # Other IDs are now the same as original IDs
+        self.assertEqual('1', browser.id.id)
+        self.assertEqual('2', version.id.id)
+        self.assertEqual('3', feature.id.id)
+        self.assertEqual('4', support.id.id)
+        self.assertEqual('5', maturity.id.id)
+        self.assertEqual('6', specification.id.id)
+        self.assertEqual('7', section.id.id)
+
+        # Linked IDs are changed as well
+        self.assertEqual('1', version.browser.id)
+        self.assertEqual(['2'], browser.versions.ids)
+        self.assertEqual('2', support.version.id)
+        self.assertEqual('3', support.feature.id)
+        self.assertEqual('5', specification.maturity.id)
+        self.assertEqual('6', section.specification.id)
+
+        # JSON API representation changes
+        expected = {
+            "versions": {
+                "version": "1.0",
+                "links": {
+                    "browser": "1",
+                },
+            }
+        }
+        self.assertEqual(expected, version.to_json_api())
+
+        # Lookup is by original ID
+        self.assertEqual(None, self.col.get('browsers', '_chrome'))
+        self.assertEqual(browser, self.col.get('browsers', '1'))
+
+    def test_override_ids_resource_without_id(self):
+        firefox = Browser(slug='firefox')
+        chrome = Browser(slug='chrome')
+        self.col.add(firefox)
+        self.col.add(chrome)
+        self.assertEqual(None, self.col.get('browsers', '1'))
+
+        other_col = Collection()
+        other_firefox = Browser(id="1", slug="firefox")
+        other_col.add(other_firefox)
+        self.col.override_ids_to_match(other_col)
+        self.assertEqual(firefox, self.col.get('browsers', '1'))
+        self.assertIsNone(chrome.id)
+
+    def test_remove(self):
+        firefox = Browser(id='_firefox', slug='firefox')
+        chrome = Browser(id='_chrome', slug='chrome')
+        self.col.add(firefox)
+        self.col.add(chrome)
+
+        self.assertEqual([chrome], self.col.filter('browsers', slug='chrome'))
+        self.assertEqual(
+            [firefox, chrome], self.col.get_resources('browsers'))
+        self.assertEqual(chrome, self.col.get('browsers', '_chrome'))
+        expected = {
+            ('browsers', 'firefox'): firefox,
+            ('browsers', 'chrome'): chrome,
+        }
+        self.assertEqual(
+            expected, self.col.get_resources_by_data_id('browsers'))
+
+        self.col.remove(chrome)
+        self.assertEqual([], self.col.filter('browsers', slug='chrome'))
+        self.assertEqual([firefox], self.col.get_resources('browsers'))
+        self.assertEqual(None, self.col.get('browsers', '_chrome'))
+        expected = {('browsers', 'firefox'): firefox}
+        self.assertEqual(
+            expected, self.col.get_resources_by_data_id('browsers'))
+
+    def test_remove_resource_without_id(self):
+        firefox = Browser(slug='firefox')
+        self.col.add(firefox)
+        self.assertEqual([firefox], self.col.get_resources('browsers'))
+        self.col.remove(firefox)
+        self.assertEqual([], self.col.get_resources('browsers'))
+
+
+class TestCollectionChangeset(TestCase):
+
+    def setUp(self):
+        self.client = Client('http://example.com')
+        self.client.request = mock.Mock()
+        self.client.request.side_effect = Exception('should not be called')
+        self.orig_col = Collection(self.client)
+        self.new_col = Collection()
+
+    def test_empty(self):
+        cc = CollectionChangeset(self.orig_col, self.new_col)
+        expected = {
+            "new": OrderedDict(),
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected, cc.changes)
+        expected_summary = ""
+        self.assertEqual(expected_summary, cc.summarize())
+
+    def setup_new(self):
+        browser = Browser(id='_chrome', slug='chrome')
+        version = Version(version='2.0', browser='_chrome')
+        self.new_col.add(browser)
+        self.new_col.add(version)
+        resources = (browser, version)
+        return resources, CollectionChangeset(self.orig_col, self.new_col)
+
+    def test_changes_new_items(self):
+        (browser, version), cc = self.setup_new()
+        expected = {
+            "new": OrderedDict([
+                (('browsers', 'chrome'), browser),
+                (('versions', 'chrome', '2.0'), version),
+            ]),
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected, cc.changes)
+
+    def test_change_original_new_items(self):
+        _, cc = self.setup_new()
+
+        def fake_request(
+                method, resource_type, resource_id=None, params=None,
+                data=None):
+            if method == 'POST' and resource_type == 'changesets':
+                return {'changesets': {'id': '_changeset'}}
+            elif method == 'POST' and resource_type == 'browsers':
+                self.assertEqual({'browsers': {'slug': 'chrome'}}, data)
+                return {'browsers': {'id': '_browser', 'slug': 'chrome'}}
+            elif method == 'POST' and resource_type == 'versions':
+                expected_data = {
+                    "versions": {
+                        "version": "2.0",
+                        "links": {"browser": "_browser"}}}
+                self.assertEqual(expected_data, data)
+                returned_data = expected_data.copy()
+                returned_data['versions']['id'] = '_version'
+                return returned_data
+            else:
+                assert (method == 'PUT' and resource_type == 'changesets'), \
+                    'Unexpected request: %s' % repr(locals())
+                self.assertEqual('_changeset', resource_id)
+                self.assertEqual({'changesets': {'closed': True}}, data)
+                return {'changesets': {'id': '_changeset', 'closed': True}}
+        self.client.request.side_effect = fake_request
+        expected = {
+            'browsers': {'new': 1},
+            'versions': {'new': 1},
+        }
+        changes = cc.change_original_collection()
+        self.assertEqual(expected, changes)
+
+    def test_summary_new_items(self):
+        _, cc = self.setup_new()
+        expected = """\
+New browsers:
+{'browsers': {'slug': 'chrome'}}
+New versions:
+{'versions': {'links': {'browser': '_chrome'}, 'version': '2.0'}}"""
+        self.assertEqual(expected, cc.summarize())
+
+    def setup_new_with_dependencies(self):
+        parent = Feature(id='parent', slug='parent')
+        child1 = Feature(id='child1', slug='child1', parent='parent')
+        child2 = Feature(id='child2', slug='child2', parent='parent')
+        child3 = Feature(id='child3', slug='child3', parent='parent')
+        grandchild = Feature(id='gchild', slug='grandchild', parent='child2')
+
+        self.new_col.add(child1)
+        self.new_col.add(parent)
+        self.new_col.add(child2)
+        self.new_col.add(child3)
+        self.new_col.add(grandchild)
+        resources = (parent, child1, child2, child3, grandchild)
+        return resources, CollectionChangeset(self.orig_col, self.new_col)
+
+    def test_changes_new_items_with_dependencies(self):
+        resources, cc = self.setup_new_with_dependencies()
+        parent, child1, child2, child3, grandchild = resources
+        expected_order = OrderedDict([
+            (('features', 'parent'), parent),
+            (('features', 'child1'), child1),
+            (('features', 'child2'), child2),
+            (('features', 'child3'), child3),
+            (('features', 'grandchild'), grandchild),
+        ])
+        expected = {
+            "new": expected_order,
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected_order.keys(), cc.changes['new'].keys())
+        self.assertEqual(expected, cc.changes)
+
+    def test_change_original_new_items_with_dependencies(self):
+        _, cc = self.setup_new_with_dependencies()
+
+        def fake_request(
+                method, resource_type, resource_id=None, params=None,
+                data=None):
+            if method == 'POST' and resource_type == 'changesets':
+                return {'changesets': {'id': '_changeset'}}
+            elif method == 'POST' and resource_type == 'features':
+                slug = data['features']['slug']
+                return {
+                    'features': {
+                        'id': '_' + slug,
+                        'slug': slug,
+                    }
+                }
+            else:
+                assert (method == 'PUT' and resource_type == 'changesets'), \
+                    'Unexpected request: %s' % repr(locals())
+                self.assertEqual('_changeset', resource_id)
+                self.assertEqual({'changesets': {'closed': True}}, data)
+                return {'changesets': {'id': '_changeset', 'closed': True}}
+        self.client.request.side_effect = fake_request
+        expected = {
+            'features': {'new': 5},
+        }
+        changes = cc.change_original_collection()
+        self.assertEqual(expected, changes)
+
+    def test_summary_new_items_with_dependencies(self):
+        _, cc = self.setup_new_with_dependencies()
+        expected = """\
+New features:
+{'features': {'slug': 'parent'}}
+New features:
+{'features': {'links': {'parent': 'parent'}, 'slug': 'child1'}}
+New features:
+{'features': {'links': {'parent': 'parent'}, 'slug': 'child2'}}
+New features:
+{'features': {'links': {'parent': 'parent'}, 'slug': 'child3'}}
+New features:
+{'features': {'links': {'parent': 'child2'}, 'slug': 'grandchild'}}"""
+        self.assertEqual(expected, cc.summarize())
+
+    def setup_deleted(self):
+        browser = Browser(id='_chrome', slug='chrome')
+        version = Version(id='_chrome_2', version='2.0', browser='_chrome')
+        self.orig_col.add(browser)
+        self.orig_col.add(version)
+        resources = (browser, version)
+        return resources, CollectionChangeset(self.orig_col, self.new_col)
+
+    def test_changes_deleted_items(self):
+        (browser, version), cc = self.setup_deleted()
+        expected = {
+            "new": OrderedDict(),
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict([
+                (('browsers', 'chrome'), browser),
+                (('versions', 'chrome', '2.0'), version),
+            ]),
+        }
+        self.assertEqual(expected, cc.changes)
+
+    def test_change_original_deleted_items(self):
+        _, cc = self.setup_deleted()
+
+        def fake_request(
+                method, resource_type, resource_id=None, params=None,
+                data=None):
+            if method == 'POST' and resource_type == 'changesets':
+                return {'changesets': {'id': '_changeset'}}
+            elif method == 'DELETE':
+                return {}
+            else:
+                assert (method == 'PUT' and resource_type == 'changesets'), \
+                    'Unexpected request: %s' % repr(locals())
+                self.assertEqual('_changeset', resource_id)
+                self.assertEqual({'changesets': {'closed': True}}, data)
+                return {'changesets': {'id': '_changeset', 'closed': True}}
+        self.client.request.side_effect = fake_request
+        expected = {
+            'browsers': {'deleted': 1},
+            'versions': {'deleted': 1},
+        }
+        changes = cc.change_original_collection()
+        self.assertEqual(expected, changes)
+
+    def test_summary_deleted_items(self):
+        _, cc = self.setup_deleted()
+        expected = """\
+Deleted http://example.com/api/v1/browsers/_chrome:
+{'browsers': {'slug': 'chrome'}}
+Deleted http://example.com/api/v1/versions/_chrome_2:
+{'versions': {'links': {'browser': '_chrome'}, 'version': '2.0'}}"""
+        self.assertEqual(expected, cc.summarize())
+
+    def setup_matched(self):
+        browser = Browser(id='1', slug='chrome')
+        version = Version(
+            id='1', version='2.0', browser='1', note={'en': 'Second Version'})
+        self.orig_col.add(browser)
+        self.orig_col.add(version)
+
+        browser_same = Browser(id='_chrome', slug='chrome')
+        version_diff = Version(
+            id='_version', version='2.0', browser='_chrome',
+            note={'en': 'Second Version', 'es': 'Segunda Versión'})
+        self.new_col.add(version_diff)
+        self.new_col.add(browser_same)
+        resources = (version, browser_same, version_diff)
+        return resources, CollectionChangeset(self.orig_col, self.new_col)
+
+    def test_changes_matched_items(self):
+        (version, browser_same, version_diff), cc = self.setup_matched()
+
+        expected = {
+            "new": OrderedDict(),
+            "same": OrderedDict([
+                (('browsers', 'chrome'), browser_same),
+            ]),
+            "changed": OrderedDict([
+                (('versions', 'chrome', '2.0'), version_diff),
+            ]),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected, cc.changes)
+        changed = cc.changes['changed'][('versions', 'chrome', '2.0')]
+        self.assertEqual(changed._original, version)
+
+    def test_change_original_matched_items(self):
+        _, cc = self.setup_matched()
+
+        def fake_request(
+                method, resource_type, resource_id=None, params=None,
+                data=None):
+            if method == 'POST' and resource_type == 'changesets':
+                return {'changesets': {'id': '_changeset'}}
+            elif method == 'PUT' and resource_type == 'versions':
+                return data
+            else:
+                assert (method == 'PUT' and resource_type == 'changesets'), \
+                    'Unexpected request: %s' % repr(locals())
+                self.assertEqual('_changeset', resource_id)
+                self.assertEqual({'changesets': {'closed': True}}, data)
+                return {'changesets': {'id': '_changeset', 'closed': True}}
+        self.client.request.side_effect = fake_request
+        expected = {
+            'versions': {'changed': 1},
+        }
+        changes = cc.change_original_collection()
+        self.assertEqual(expected, changes)
+
+    def test_summary_matched_items(self):
+        _, cc = self.setup_matched()
+        if six.PY3:  # pragma nocover
+            expected = """\
+Changed: http://example.com/api/v1/versions/1:
+  {'versions': {'links': {'browser': '1'},
+-               'note': {'en': 'Second Version'},
++               'note': {'en': 'Second Version', 'es': 'Segunda Versión'},
+?                                              +++++++++++++++++++++++++
+                'version': '2.0'}}"""
+        else:  # pragma nocover
+            expected = """\
+Changed: http://example.com/api/v1/versions/1:
+  {'versions': {'links': {'browser': '1'},
+-               'note': {'en': 'Second Version'},
+?                                              -
++               'note': {'en': 'Second Version',
++                        'es': 'Segunda Versi\\xc3\\xb3n'},
+                'version': '2.0'}}"""
+        self.assertEqual(expected, cc.summarize())
+
+    def test_new_browser_with_ordered_versions(self):
+        """When order matters, creation order is sort order."""
+        browser = Browser(
+            id='_b', slug='browser', versions=['u', '1.0', '2.0'])
+        v_unknown = Version(id='u', version=None, browser='_b')
+        v_1 = Version(id='1.0', version='1.0', browser='_b')
+        v_2 = Version(id='2.0', version='2.0', browser='_b')
+        self.new_col.add(browser)
+        self.new_col.add(v_1)
+        self.new_col.add(v_unknown)
+        self.new_col.add(v_2)
+        cc = CollectionChangeset(self.orig_col, self.new_col)
+        expected_order = OrderedDict([
+            (('browsers', 'browser'), browser),
+            (('versions', 'browser', ''), v_unknown),
+            (('versions', 'browser', '1.0'), v_1),
+            (('versions', 'browser', '2.0'), v_2),
+        ])
+        expected = {
+            "new": expected_order,
+            "same": OrderedDict(),
+            "changed": OrderedDict(),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected_order.keys(), cc.changes['new'].keys())
+        self.assertEqual(expected, cc.changes)
+
+    def test_new_versions_to_existing_browser(self):
+        """When order matters, new items update the parent item."""
+        browser = Browser(
+            id='_b', slug='browser', versions=['u'])
+        v_1 = Version(id='1.0', version='1.0', browser='_b')
+        self.orig_col.add(browser)
+        self.orig_col.add(v_1)
+
+        browser_new = Browser(
+            id='_b', slug='browser', versions=['u', '1.0', '2.0'])
+        v_unknown = Version(id='u', version=None, browser='_b')
+        v_1_same = Version(id='1.0', version='1.0', browser='_b')
+        v_2 = Version(id='2.0', version='2.0', browser='_b')
+        self.new_col.add(browser_new)
+        self.new_col.add(v_unknown)
+        self.new_col.add(v_1_same)
+        self.new_col.add(v_2)
+        cc = CollectionChangeset(self.orig_col, self.new_col)
+        expected_order = OrderedDict([
+            (('versions', 'browser', ''), v_unknown),
+            (('versions', 'browser', '2.0'), v_2),
+        ])
+        expected = {
+            "new": expected_order,
+            "same": OrderedDict([
+                (('versions', 'browser', '1.0'), v_1_same),
+            ]),
+            "changed": OrderedDict([
+                (('browsers', 'browser'), browser_new),
+            ]),
+            "deleted": OrderedDict(),
+        }
+        self.assertEqual(expected_order.keys(), cc.changes['new'].keys())
+        self.assertEqual(expected, cc.changes)

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import codecs
+import getpass
+import json
+import logging
+import os.path
+import sys
+
+from client import Client
+from resources import Collection, CollectionChangeset
+
+try:
+    input = raw_input  # Get the Py2 raw_input
+except NameError:
+    pass  # We're in Py3
+
+logger_name = 'upload_data'
+logger = logging.getLogger(logger_name)
+
+resources = [
+    'browsers',
+    'versions',
+    'features',
+    'supports',
+    'specifications',
+    'maturities',
+    'sections',
+]
+
+
+def upload_data(client, base_dir='', confirm=None):
+    """Upload data to the API"""
+    api_collection = Collection(client)
+    local_collection = Collection()
+
+    logger.info('Reading existing data from API')
+    load_api_data(api_collection)
+    logger.info('Reading upload data from disk')
+    load_local_data(local_collection, base_dir)
+
+    logger.info('Looking for changes...')
+    changeset = CollectionChangeset(api_collection, local_collection)
+    delta = changeset.changes
+
+    if delta['new'] or delta['changed'] or delta['deleted']:
+        logger.info(
+            'Changes detected: %d new, %d changed, %d deleted, %d same.',
+            len(delta['new']), len(delta['changed']), len(delta['deleted']),
+            len(delta['same']))
+        if confirm:
+            confirmed = confirm(client, changeset)
+        else:
+            confirmed = True
+        if not confirmed:
+            return {}
+    else:
+        logger.info('No changes')
+        return {}
+
+    counts = changeset.change_original_collection(logger_name)
+    return counts
+
+
+def load_api_data(api_collection):
+    for resource in resources:
+        data = client.get_resources(resource, 'upload_data')
+        resource_class = api_collection.resource_by_type[resource]
+        for item in data[resource]:
+            obj = resource_class()
+            obj.from_json_api({resource: item})
+            api_collection.add(obj)
+        logger.info("Downloaded %d %s.", len(data[resource]), resource)
+
+
+def load_local_data(local_collection, base_dir):
+    for resource in resources:
+        filepath = os.path.join(base_dir, '%s.json' % resource)
+        with codecs.open(filepath, 'r', 'utf8') as f:
+            data = json.load(f)
+        resource_class = local_collection.resource_by_type[resource]
+        for item in data[resource]:
+            obj = resource_class()
+            obj.from_json_api({resource: item})
+            local_collection.add(obj)
+
+
+def confirm_changes(client, changeset):
+    while True:
+        choice = input("Make these changes? (Y/N/D for details) ")
+        if choice.upper() == 'Y':
+            return True
+        elif choice.upper() == 'N':
+            return False
+        elif choice.upper() == 'D':
+            print(changeset.summarize())
+        else:
+            print("Please type Y or N or D.")
+
+
+if __name__ == '__main__':
+    import argparse
+    description = 'Download data from API.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '-a', '--api',
+        help='Base URL of the API (default: http://localhost:8000)',
+        default="http://localhost:8000")
+    parser.add_argument(
+        '-u', '--user',
+        help='Username on API (default: prompt for username)')
+    parser.add_argument(
+        '-v', '--verbose', action="store_true",
+        help='Print extra debug information')
+    parser.add_argument(
+        '-q', '--quiet', action="store_true",
+        help='Only print warnings')
+    parser.add_argument(
+        '-d', '--data', default='data',
+        help='Input data folder (default: data)')
+    args = parser.parse_args()
+
+    # Setup logging
+    verbose = args.verbose
+    quiet = args.quiet
+    console = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    fmat = '%(levelname)s - %(message)s'
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+        logger_name = ''
+        fmat = '%(name)s - %(levelname)s - %(message)s'
+    else:
+        level = logging.INFO
+    formatter = logging.Formatter(fmat)
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    logger.addHandler(console)
+
+    # Parse arguments
+    api = args.api
+    if api.endswith('/'):
+        api = api[:-1]
+    data = args.data
+    if data.endswith('/'):
+        data = data[:-1]
+    logger.info("Uploading data from %s to %s", data, api)
+
+    # Get credentials
+    user = args.user or input("API username: ")
+    password = getpass.getpass("API password: ")
+
+    # Initialize client
+    client = Client(api)
+    client.login(user, password)
+
+    # Load data
+    counts = upload_data(client, data, confirm_changes)
+
+    if counts:
+        logger.info("Changes complete. Counts:")
+        for resource_type, changes in counts.items():
+            c_new = changes.get('new', 0)
+            c_deleted = changes.get('deleted', 0)
+            c_changed = changes.get('changed', 0)
+            c_text = []
+            if c_new:
+                c_text.append("%d new" % c_new)
+            if c_deleted:
+                c_text.append("%d deleted" % c_deleted)
+            if c_changed:
+                c_text.append("%d changed" % c_changed)
+            if c_text:
+                logger.info("  %s: %s" % (
+                    resource_type.title(), ', '.join(c_text)))
+    else:
+        logger.info("No data uploaded.")

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -17,8 +17,7 @@ try:
 except NameError:
     pass  # We're in Py3
 
-logger_name = 'upload_data'
-logger = logging.getLogger(logger_name)
+logger = logging.getLogger('tools.upload_data')
 
 resources = [
     'browsers',
@@ -60,19 +59,14 @@ def upload_data(client, base_dir='', confirm=None):
         logger.info('No changes')
         return {}
 
-    counts = changeset.change_original_collection(logger_name)
+    counts = changeset.change_original_collection()
     return counts
 
 
 def load_api_data(api_collection):
     for resource in resources:
-        data = client.get_resources(resource, 'upload_data')
-        resource_class = api_collection.resource_by_type[resource]
-        for item in data[resource]:
-            obj = resource_class()
-            obj.from_json_api({resource: item})
-            api_collection.add(obj)
-        logger.info("Downloaded %d %s.", len(data[resource]), resource)
+        count = api_collection.load_all(resource)
+        logger.info("Downloaded %d %s.", count, resource)
 
 
 def load_local_data(local_collection, base_dir):
@@ -128,6 +122,7 @@ if __name__ == '__main__':
     console = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter('%(levelname)s - %(message)s')
     fmat = '%(levelname)s - %(message)s'
+    logger_name = 'tools'
     if quiet:
         level = logging.WARNING
     elif verbose:

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+from collections import OrderedDict
 import codecs
 import getpass
 import json
@@ -73,7 +74,7 @@ def load_local_data(local_collection, base_dir):
     for resource in resources:
         filepath = os.path.join(base_dir, '%s.json' % resource)
         with codecs.open(filepath, 'r', 'utf8') as f:
-            data = json.load(f)
+            data = json.load(f, object_pairs_hook=OrderedDict)
         resource_class = local_collection.resource_by_type[resource]
         for item in data[resource]:
             obj = resource_class()

--- a/webplatformcompat/cache.py
+++ b/webplatformcompat/cache.py
@@ -237,7 +237,7 @@ class Cache(BaseCache):
     def maturity_v1_add_related_pks(self, obj):
         """Add related primary keys to a Maturity instance."""
         if not hasattr(obj, '_specification_pks'):
-            obj._specification_pks = list(
+            obj._specification_pks = sorted(
                 obj.specifications.values_list('pk', flat=True))
         if not hasattr(obj, '_history_pks'):
             obj._history_pks = list(
@@ -285,7 +285,7 @@ class Cache(BaseCache):
             obj._history_pks = list(
                 obj.history.all().values_list('history_id', flat=True))
         if not hasattr(obj, '_feature_pks'):
-            obj._feature_pks = list(
+            obj._feature_pks = sorted(
                 obj.features.values_list('pk', flat=True))
 
     def section_v1_invalidator(self, obj):
@@ -423,7 +423,8 @@ class Cache(BaseCache):
     def version_v1_add_related_pks(self, obj):
         """Add related primary keys to a Version instance."""
         if not hasattr(obj, '_support_pks'):
-            obj._support_pks = list(obj.supports.values_list('pk', flat=True))
+            obj._support_pks = sorted(
+                obj.supports.values_list('pk', flat=True))
         if not hasattr(obj, '_history_pks'):
             obj._history_pks = list(
                 obj.history.all().values_list('history_id', flat=True))

--- a/webplatformcompat/drf_fields.py
+++ b/webplatformcompat/drf_fields.py
@@ -232,7 +232,8 @@ class TranslatedTextField(CharField):
         """Convert from serializable data to model"""
         if isinstance(value, dict):
             return value
-        value = value.strip()
+        if value:
+            value = value.strip()
         if value:
             try:
                 native = json.loads(value)

--- a/webplatformcompat/drf_fields.py
+++ b/webplatformcompat/drf_fields.py
@@ -2,6 +2,7 @@
 """Fields for Django REST Framework serializers."""
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 import json
 
 from django.core.exceptions import ValidationError
@@ -224,7 +225,13 @@ class TranslatedTextField(CharField):
                 else:
                     return None
             else:
-                return value
+                out = OrderedDict()
+                if 'en' in value:
+                    out['en'] = value['en']
+                for lang in sorted(value.keys()):
+                    if lang != 'en':
+                        out[lang] = value[lang]
+                return out
         else:
             return None
 

--- a/webplatformcompat/helpers.py
+++ b/webplatformcompat/helpers.py
@@ -4,7 +4,67 @@ This file is loaded by jingo and must be named helper.py
 """
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.html import escape
 
-import jingo
+from jinja2 import contextfunction, Markup
+from jingo import register
 
-jingo.register.function(static)
+
+def pick_translation(context, trans_obj):
+    """Pick a translation from a translation object.
+
+    A translation object may be:
+    Empty -- No content, return ('', None)
+    A string -- A canonical string, return (string, None)
+    A dictionary -- Language/string pairs, return (string, language)
+    """
+    if not trans_obj:
+        return '', None
+    if not hasattr(trans_obj, 'keys'):
+        return trans_obj, None
+    lang = context.get('lang', 'en')
+    if lang not in trans_obj:
+        assert 'en' in trans_obj
+        lang = 'en'
+    return trans_obj[lang], lang
+
+
+@register.function
+@contextfunction
+def trans_span(context, trans_obj, **attrs):
+    """Pick a translation for an HTML element.
+
+    The text is HTML-escaped and marked HTML-safe.  If the requested language
+    does not match, the result is wrapped in a <span> with a lang= attribute.
+    Other key=value pairs are added as span attributes.  If the requested
+    language matches, and there are no span attributes, the <span> element is
+    omitted and plain (HTML-safe) text is returned.
+    """
+    desired_lang = context.get('lang', 'en')
+    trans, lang = pick_translation(context, trans_obj)
+    if not lang:
+        if trans:
+            return Markup(u'<code>{0}</code>'.format(escape(trans)))
+        else:
+            return ''
+    if desired_lang != lang:
+        attrs['lang'] = lang
+    if attrs:
+        attrstr = ' '.join(
+            ['{0}="{1}"'.format(k, attrs[k]) for k in sorted(attrs.keys())])
+        return Markup(u'<span {1}>{0}</span>'.format(trans, attrstr))
+    else:
+        return Markup(trans)
+
+
+@register.function
+@contextfunction
+def trans_str(context, trans_obj):
+    """Pick a translation as an unescaped string.
+
+    The string is not wrapped in an HTML element and not marked as HTML safe.
+    """
+    return pick_translation(context, trans_obj)[0]
+
+
+register.function(static)

--- a/webplatformcompat/models.py
+++ b/webplatformcompat/models.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.db.models.signals import (post_delete, post_save, m2m_changed)
+from django.db.models.signals import post_delete, post_save, m2m_changed
 from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django_extensions.db.fields.json import JSONField
@@ -313,9 +313,9 @@ def feature_sections_changed_update_order(
 
     from .tasks import update_cache_for_instance
     for feature in features:
-        update_cache_for_instance('Feature', feature.pk, feature)
+        update_cache_for_instance('Feature', feature.pk, feature, False)
     for section in sections:
-        update_cache_for_instance('Section', section.pk, section)
+        update_cache_for_instance('Section', section.pk, section, False)
 
 
 @receiver(post_delete, dispatch_uid='post_delete_update_cache')
@@ -323,7 +323,7 @@ def post_delete_update_cache(sender, instance, **kwargs):
     name = sender.__name__
     if name in cached_model_names:
         from .tasks import update_cache_for_instance
-        update_cache_for_instance(name, instance.pk, instance)
+        update_cache_for_instance(name, instance.pk, instance, False)
 
 
 @receiver(post_save, dispatch_uid='post_save_update_cache')
@@ -335,4 +335,4 @@ def post_save_update_cache(sender, instance, created, raw, **kwargs):
         delay_cache = getattr(instance, '_delay_cache', False)
         if not delay_cache:
             from .tasks import update_cache_for_instance
-            update_cache_for_instance(name, instance.pk, instance)
+            update_cache_for_instance(name, instance.pk, instance, False)

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -67,10 +67,10 @@ class JsonApiRenderer(BaseJsonApiRender):
         view_name = '%(model_name)s-detail' % format_kwargs
 
         assert field_name in resource
-        links[field_name] = {
-            "type": resource_type,
-            "href": self.url_to_template(view_name, request, field_name)
-        }
+        links[field_name] = self.dict_class((
+            ("type", resource_type),
+            ("href", self.url_to_template(view_name, request, field_name)),
+        ))
 
         if field.many:
             pks = resource[field_name]

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
+from json import loads
 
-from django.utils import encoding
+from django.utils import encoding, translation
 
+from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.utils.encoders import JSONEncoder
 from rest_framework_json_api.renderers import JsonApiRenderer \
     as BaseJsonApiRender
@@ -90,3 +92,46 @@ class JsonApiRenderer(BaseJsonApiRender):
             linked_ids[field_name] = link_data[0]
 
         return {"linked_ids": linked_ids, "links": links}
+
+
+class JsonApiTemplateHTMLRenderer(TemplateHTMLRenderer):
+    """Render to a template, but use JSON API format as context."""
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        """Generate JSON API representation, as well as collection."""
+        # Set the context to the JSON API represention
+        json_api_renderer = JsonApiRenderer()
+        json_api = json_api_renderer.render(
+            data, accepted_media_type, renderer_context)
+        context = loads(json_api.decode('utf-8'))
+
+        # Copy main item to generic 'data' key
+        other_keys = ('linked', 'links', 'meta')
+        main_keys = [m for m in context.keys() if m not in other_keys]
+        assert len(main_keys) == 1
+        main_type = main_keys[0]
+        main_obj = context[main_type].copy()
+        main_id = main_obj['id']
+        context['data'] = main_obj
+        context['data']['type'] = main_type
+
+        # Add a collection of types and IDs
+        collection = {}
+        for resource_type, resources in context.get('linked', {}).items():
+            assert resource_type not in collection
+            collection[resource_type] = {}
+            for resource in resources:
+                resource_id = resource['id']
+                assert resource_id not in collection[resource_type]
+                collection[resource_type][resource_id] = resource
+        collection.setdefault(main_type, {})[main_id] = main_obj
+        context['collection'] = collection
+
+        # Add language
+        request = renderer_context['request']
+        lang = request.GET.get('lang', translation.get_language())
+        context['lang'] = lang
+
+        # Render HTML template w/ context
+        return super(JsonApiTemplateHTMLRenderer, self).render(
+            context, accepted_media_type, renderer_context)

--- a/webplatformcompat/renderers.py
+++ b/webplatformcompat/renderers.py
@@ -103,7 +103,8 @@ class JsonApiTemplateHTMLRenderer(TemplateHTMLRenderer):
         json_api_renderer = JsonApiRenderer()
         json_api = json_api_renderer.render(
             data, accepted_media_type, renderer_context)
-        context = loads(json_api.decode('utf-8'))
+        context = loads(
+            json_api.decode('utf-8'), object_pairs_hook=OrderedDict)
 
         # Copy main item to generic 'data' key
         other_keys = ('linked', 'links', 'meta')

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -683,8 +683,7 @@ class ViewFeatureExtraSerializer(ModelSerializer):
         # Order significant features
         significant_changes = OrderedDict()
         for f_id in chain([obj.id], [f.id for f in obj.child_features]):
-            if f_id in sig_features:
-                significant_changes[str(f_id)] = sig_features[f_id]
+            significant_changes[str(f_id)] = sig_features.get(f_id, {})
 
         return significant_changes
 
@@ -741,9 +740,12 @@ class ViewFeatureExtraSerializer(ModelSerializer):
             'next': None,
             'count': obj.descendant_count
         }
+        url_kwargs = {'pk': obj.id}
+        if self.context['format']:
+            url_kwargs['format'] = self.context['format']
+        request = self.context['request']
         url = reverse(
-            'viewfeatures-detail', kwargs={'pk': obj.id},
-            request=self.context['request'])
+            'viewfeatures-detail', kwargs=url_kwargs, request=request)
         if obj.page_child_features.has_previous():
             pagination['previous'] = (
                 url + '?page=' +

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -500,6 +500,10 @@ Browse.FeatureController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
     versionCountText: Browse.Properties.IdCounterText('versionCount', 'Version'),
     childCount: Browse.Properties.IdCounter('children'),
     childCountText: Browse.Properties.IdCounterText('childCount', 'Child', 'Children'),
+    viewUrl: Ember.computed('id', function () {
+        var id = this.get('id');
+        return "/view_feature/" + id;
+    }),
 });
 
 Browse.SupportController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -309,15 +309,33 @@ Browse.Properties = {
             return property;
         });
     },
+    OptionalDateHTML: function (propertyName) {
+        return Ember.computed(propertyName, function () {
+            var date = this.get(propertyName), year, month, day;
+            if (date) {
+                year = date.getFullYear();
+                month = (date.getMonth() + 1).toString();
+                day = date.getDate().toString();
+                return year + '-' +
+                    (month.length < 2 ? '0' : '') + month + '-' +
+                    (day.length < 2 ? '0' : '') + day;
+            }
+            return '<em>none</em>';
+        });
+    },
     TranslationDefaultHTML: function (propertyName) {
         /* Turn a translation object into default HTML */
         return Ember.computed(propertyName, function () {
-            var property = this.get(propertyName);
+            var property = this.get(propertyName), en;
             if (!property) { return '<em>none</em>'; }
             if (typeof property === 'string') {
                 return '<code>' + property + '</code>';
             }
-            return property.en;
+            en = property.en;
+            if (en.indexOf('https://') === 0 || en.indexOf('http://') === 0) {
+                return '<a href="' + en + '">' + en + '</a>';
+            }
+            return en;
         });
     },
     TranslationArray: function (propertyName) {
@@ -365,11 +383,19 @@ Browse.Properties = {
                 arrayLen = array.length,
                 ul = "<ul>",
                 item,
-                i;
+                i,
+                val;
             if (arrayLen === 0) { return '<em>none</em>'; }
             for (i = 0; i < arrayLen; i += 1) {
                 item = array[i];
-                ul += '<li>' + item.lang + ': ' + item.value + '</li>';
+                val = item.value;
+                ul += '<li>' + item.lang + ': ';
+                if (val.indexOf('https://') === 0 || val.indexOf('http://') === 0) {
+                    ul += '<a href="' + val + '">' + val + '</a>';
+                } else {
+                    ul += val;
+                }
+                ul += '</li>';
             }
             ul += '</ul>';
             return ul;
@@ -411,12 +437,12 @@ Browse.VersionController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
         }
         return out;
     }),
-    releaseDayHTML: Browse.Properties.OptionalHTML('release_day'),
-    retirementDayHTML: Browse.Properties.OptionalHTML('retirement_day'),
+    releaseDayHTML: Browse.Properties.OptionalDateHTML('release_day'),
+    retirementDayHTML: Browse.Properties.OptionalDateHTML('retirement_day'),
     featureCount: Browse.Properties.IdCounter('supports'),
     featureCountText: Browse.Properties.IdCounterText('featureCount', 'Feature'),
-    releaseNoteUriArray: Browse.Properties.TranslationArray('releaseNoteUri'),
-    releaseNoteUriDefaultHTML: Browse.Properties.TranslationDefaultHTML('releaseNoteUri'),
+    releaseNoteUriArray: Browse.Properties.TranslationArray('release_notes_uri'),
+    releaseNoteUriDefaultHTML: Browse.Properties.TranslationDefaultHTML('release_notes_uri'),
     releaseNoteUriListHTML: Browse.Properties.TranslationListHTML('releaseNoteUriArray'),
     noteArray: Browse.Properties.TranslationArray('note'),
     noteDefaultHTML: Browse.Properties.TranslationDefaultHTML('note'),

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -1,0 +1,344 @@
+"use strict";
+/*global window: false, document: false */
+
+window.WPC = {
+    parse_resources: function (obj) {
+        /* Parse resources from a JSON API response */
+        var key, value, rType, rItem, rArray, rIdx, rCnt, resources = {};
+
+        for (key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                value = obj[key];
+                if (key === 'linked') {
+                    /* linked is a dictionary of resource type strings
+                     * ("browsers", "versions", etc.) to an array of
+                     * resource representations.  Turn this into a
+                     * dictionary of IDs to representations
+                     */
+                    for (rType in value) {
+                        if (value.hasOwnProperty(rType)) {
+                            resources[rType] = {};
+                            rArray = value[rType];
+                            rCnt = rArray.length;
+                            for (rIdx = 0; rIdx < rCnt; rIdx += 1) {
+                                rItem = rArray[rIdx];
+                                resources[rType][rItem.id] = rItem;
+                            }
+                        }
+                    }
+                } else if (key === 'meta' || key === 'links') {
+                    /* "meta" is meta data for the request, such as pagination
+                     * "links" contains link patterns for related objects
+                     * Copy to the resources
+                     */
+                    resources[key] = obj[key];
+                } else {
+                    /* Key is a resource type string ("browsers", etc.)
+                     * and value is the main item.  Copy to the special
+                     * "data" key, as well as the resource by type by ID lookup
+                     */
+                    value = obj[key];
+                    if (!resources.hasOwnProperty(key)) {
+                        resources[key] = {};
+                    }
+                    resources[key][value.id] = value;
+                    resources.data = value;
+                }
+            }
+        }
+        return resources;
+    },
+    trans_span: function (trans, lang) {
+        var span = document.createElement('span');
+        span.innerHTML = this.trans_str(trans, lang);
+        return span;
+    },
+    trans_str: function (trans, lang) {
+        if (trans === null || trans === undefined) {
+            return null;
+        }
+        if (trans.hasOwnProperty(lang)) {
+            return trans[lang];
+        }
+        if (trans.hasOwnProperty('en')) {
+            return trans.en;
+        }
+        return '';
+    },
+    generate_specification_table: function (resources, lang) {
+        var table, thead, tbody, tr, th, td, a, sCnt, sIdx, sectionId,
+            section, spec, maturity, matClass, small, span;
+        if (resources.data.links.sections) {
+            // Create the table
+            table = document.createElement('table');
+            table.setAttribute('class', 'wpc-specifications-table table');
+
+            // Create the table header
+            thead = document.createElement('thead');
+            tr = document.createElement('tr');
+            th = document.createElement('th');
+            th.innerHTML = "Specification";
+            tr.appendChild(th);
+            th = document.createElement('th');
+            th.innerHTML = "Status";
+            tr.appendChild(th);
+            th = document.createElement('th');
+            th.innerHTML = "Comment";
+            tr.appendChild(th);
+            thead.appendChild(tr);
+            table.appendChild(thead);
+
+            // Create the table body
+            tbody = document.createElement('tbody');
+            sCnt = resources.data.links.sections.length;
+            for (sIdx = 0; sIdx < sCnt; sIdx += 1) {
+                sectionId = resources.data.links.sections[sIdx];
+                section = resources.sections[sectionId];
+                spec = resources.specifications[section.links.specification];
+                maturity = resources.maturities[spec.links.maturity];
+                matClass = "maturity-" + maturity.slug;
+                tr = document.createElement('tr');
+
+                td = document.createElement('td');
+                a = document.createElement('a');
+                a.setAttribute('href', this.trans_str(spec.uri, lang) + this.trans_str(section.subpath, lang));
+                a.appendChild(this.trans_span(spec.name, lang));
+                a.appendChild(document.createElement('br'));
+                small = document.createElement('small');
+                small.appendChild(this.trans_span(section.number, lang));
+                small.appendChild(document.createTextNode(' '));
+                small.appendChild(this.trans_span(section.name, lang));
+                a.appendChild(small);
+                td.appendChild(a);
+                tr.appendChild(td);
+
+                td = document.createElement('td');
+                span = this.trans_span(maturity.name, lang);
+                span.setAttribute('class', matClass);
+                td.appendChild(span);
+                tr.appendChild(td);
+
+                td = document.createElement('td');
+                if (section.note) {
+                    td.appendChild(this.trans_span(section.note, lang));
+                }
+                tr.appendChild(td);
+
+                tbody.appendChild(tr);
+            }
+            table.appendChild(tbody);
+
+            return table;
+        }
+        return null;
+    },
+    generate_browser_tables: function (resources, lang) {
+        var idPrefix, tabs, tabCnt, tabIdx, tab, panel, tabList, tabContent,
+            tabListItem, tabContentItem, tabId, a, table, thead, tr, th,
+            browserCnt, browserIdx, browserId, browser, tbody, supportMap,
+            featureId, browserMap, feature, td, supports, supportCnt, supportIdx,
+            supportId, support, versionId, version, releaseUri, versionLink,
+            prefix, note, noteTxt, footnoteNum, footnoteId, footnote, backlink,
+            footnoteArray, footnoteDiv, footnoteCnt, footnoteIdx;
+        if (resources.meta.compat_table.tabs) {
+            idPrefix = 'wpc-compat-' + resources.data.id;
+            tabs = resources.meta.compat_table.tabs;
+            tabCnt = tabs.length;
+
+            // Add bootstrap tab control for browser types (Desktop, etc.)
+            panel = document.createElement('div');
+            panel.setAttribute('role', 'tabpanel');
+            tabList = document.createElement('ul');
+            tabList.setAttribute('class', 'nav nav-tabs');
+            tabList.setAttribute('role', 'tablist');
+            tabContent = document.createElement('div');
+            tabContent.setAttribute('class', 'tab-content');
+            for (tabIdx = 0; tabIdx < tabCnt; tabIdx += 1) {
+                tab = tabs[tabIdx];
+                tabId = idPrefix + '_' + tabIdx;
+
+                tabListItem = document.createElement('li');
+                tabListItem.setAttribute('role', 'presentation');
+                if (tabIdx === 0) {
+                    tabListItem.setAttribute('class', 'active');
+                }
+                a = document.createElement('a');
+                a.setAttribute('href', "#" + tabId);
+                a.setAttribute('aria-controls', tabId);
+                a.setAttribute('role', 'tab');
+                a.setAttribute('data-toggle', 'tab');
+                a.appendChild(this.trans_span(tab.name, lang));
+                tabListItem.appendChild(a);
+                tabList.appendChild(tabListItem);
+
+                tabContentItem = document.createElement('div');
+                tabContentItem.setAttribute('role', 'tabpanel');
+                tabContentItem.setAttribute('id', tabId);
+                if (tabIdx === 0) {
+                    tabContentItem.setAttribute('class', 'tab-pane active');
+                } else {
+                    tabContentItem.setAttribute('class', 'tab-pane');
+                }
+
+                // Add the compat table for browser type
+                table = document.createElement('table');
+                table.setAttribute('class', 'table table-striped compat-table');
+
+                thead = document.createElement('thead');
+
+                tr = document.createElement('tr');
+                th = document.createElement('th');
+                th.appendChild(document.createTextNode('Feature'));
+                tr.appendChild(th);
+
+                browserCnt = tab.browsers.length;
+                for (browserIdx = 0; browserIdx < browserCnt; browserIdx += 1) {
+                    browserId = tab.browsers[browserIdx];
+                    browser = resources.browsers[browserId];
+                    th = document.createElement('th');
+                    th.appendChild(this.trans_span(browser.name, lang));
+                    tr.appendChild(th);
+                }
+                thead.appendChild(tr);
+
+                // Add the compat table body (rows of sub-features)
+                tbody = document.createElement('tbody');
+                supportMap = resources.meta.compat_table.supports;
+                for (featureId in supportMap) {
+                    if (supportMap.hasOwnProperty(featureId) &&
+                            featureId !== resources.data.id) {
+                        browserMap = supportMap[featureId];
+                        feature = resources.features[featureId];
+                        tr = document.createElement('tr');
+                        td = document.createElement('td');
+                        td.appendChild(this.trans_span(feature.name, lang));
+                        tr.appendChild(td);
+
+                        for (browserIdx = 0; browserIdx < browserCnt; browserIdx += 1) {
+                            browserId = tab.browsers[browserIdx];
+                            browser = resources.browsers[browserId];
+
+                            // Add each version / support for sub-feature / browser
+                            td = document.createElement('td');
+                            supports = browserMap[browserId];
+                            if (supports) {
+                                supportCnt = supports.length;
+                                for (supportIdx = 0; supportIdx < supportCnt; supportIdx += 1) {
+                                    supportId = supports[supportIdx];
+                                    support = resources.supports[supportId];
+                                    versionId = support.links.version;
+                                    version = resources.versions[versionId];
+
+                                    // Version with support text
+                                    if (supportIdx !== 0) {
+                                        td.appendChild(document.createElement('br'));
+                                    }
+                                    if (version.version) {
+                                        releaseUri = this.trans_str(version.release_notes_uri, lang);
+                                        if (releaseUri) {
+                                            versionLink = document.createElement('a');
+                                            versionLink.setAttribute('href', releaseUri);
+                                            versionLink.setAttribute('title', 'Release Notes');
+                                            versionLink.appendChild(document.createTextNode(version.version));
+                                            td.appendChild(versionLink);
+                                        } else {
+                                            td.appendChild(document.createTextNode(version.version));
+                                        }
+                                        if (support.support !== 'yes') {
+                                            td.appendChild(document.createTextNode(' (' + support.support + ')'));
+                                        }
+                                    } else {
+                                        td.appendChild(document.createTextNode('(' + support.support + ')'));
+                                    }
+
+                                    // Prefix
+                                    if (support.prefix && support.prefix_mandatory) {
+                                        td.appendChild(document.createTextNode(' '));
+                                        prefix = document.createElement('code');
+                                        prefix.appendChild(document.createTextNode(support.prefix));
+                                        td.appendChild(prefix);
+                                    } else {
+                                        prefix = null;
+                                    }
+
+                                    // Note
+                                    if (support.note) {
+                                        td.appendChild(document.createTextNode(' '));
+                                        noteTxt = "(" + this.trans_str(support.note) + ")";
+                                        note = document.createElement("span");
+                                        note.appendChild(document.createTextNode(noteTxt));
+                                        td.appendChild(note);
+                                    } else {
+                                        note = null;
+                                    }
+
+                                    // Footnote
+                                    if (support.footnote) {
+                                        td.appendChild(document.createTextNode(' '));
+                                        footnoteNum = resources.meta.compat_table.footnotes[supportId];
+                                        footnoteId = 'wpc-compat-' + resources.data.id + '-footnote-' + footnoteNum;
+                                        footnote = document.createElement('a');
+                                        footnote.setAttribute('id', footnoteId + '-back');
+                                        footnote.setAttribute('href', '#' + footnoteId);
+                                        footnote.appendChild(document.createTextNode(footnoteNum));
+                                        td.appendChild(footnote);
+                                    } else {
+                                        footnote = null;
+                                    }
+                                }
+                            } else {
+                                td.appendChild(document.createTextNode('?'));
+                            }
+                            tr.appendChild(td);
+                        }
+
+                        tbody.appendChild(tr);
+                    }
+                }
+
+                table.appendChild(thead);
+                table.appendChild(tbody);
+                tabContentItem.appendChild(table);
+                tabContent.appendChild(tabContentItem);
+            }
+
+            // Add footnotes
+            if (resources.meta.compat_table.footnotes) {
+                supportMap = resources.meta.compat_table.footnotes;
+                footnoteArray = [];
+                for (supportId in supportMap) {
+                    if (supportMap.hasOwnProperty(supportId)) {
+                        support = resources.supports[supportId];
+                        footnoteNum = supportMap[supportId];
+                        footnote = document.createElement('p');
+                        footnoteId = 'wpc-compat-' + resources.data.id + '-footnote-' + footnoteNum;
+                        footnote.setAttribute('id', footnoteId);
+                        backlink = document.createElement('a');
+                        backlink.setAttribute('href', '#' + footnoteId + '-back');
+                        backlink.appendChild(document.createTextNode('[' + footnoteNum + ']'));
+                        footnote.appendChild(backlink);
+                        footnote.appendChild(document.createTextNode(' '));
+                        footnote.appendChild(this.trans_span(support.footnote, lang));
+                        footnoteArray[footnoteNum] = footnote;
+                    }
+                }
+                footnoteDiv = document.createElement('div');
+                footnoteDiv.setAttribute('id', 'wpc-compat-' + resources.data.id + '-footnotes');
+                footnoteCnt = footnoteArray.length;
+                for (footnoteIdx = 1; footnoteIdx < footnoteCnt; footnoteIdx += 1) {
+                    footnoteDiv.appendChild(footnoteArray[footnoteIdx]);
+                }
+            } else {
+                footnoteDiv = null;
+            }
+
+            panel.appendChild(tabList);
+            panel.appendChild(tabContent);
+            if (footnoteDiv) {
+                panel.appendChild(footnoteDiv);
+            }
+            return panel;
+        }
+        return null;
+    },
+};

--- a/webplatformcompat/tasks.py
+++ b/webplatformcompat/tasks.py
@@ -1,13 +1,20 @@
 from celery import shared_task
+from django.conf import settings
 
 from .cache import Cache
+
+DRF_INSTANCE_CACHE_POPULATE_COLD = getattr(
+    settings, 'DRF_INSTANCE_CACHE_POPULATE_COLD', True)
 
 
 @shared_task(ignore_result=True)
 def update_cache_for_instance(
-        model_name, instance_pk, instance=None, version=None):
+        model_name, instance_pk, instance=None, version=None,
+        update_only=True):
     cache = Cache()
-    invalid = cache.update_instance(model_name, instance_pk, instance, version)
+    invalid = cache.update_instance(
+        model_name, instance_pk, instance, version, update_only=update_only)
     for invalid_name, invalid_pk, invalid_version in invalid:
         update_cache_for_instance.delay(
-            invalid_name, invalid_pk, version=invalid_version)
+            invalid_name, invalid_pk, version=invalid_version,
+            update_only=not DRF_INSTANCE_CACHE_POPULATE_COLD)

--- a/webplatformcompat/templates/webplatformcompat/base.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/base.jinja2
@@ -21,7 +21,7 @@
     {% block body_container -%}
     <div class="container">
         {% block body_title_elem -%}
-        <h1>{% block body_title %}TODO: set block title{% endblock %}</h1>
+        <h1 id="body_title">{% block body_title %}TODO: set block body_title{% endblock %}</h1>
         {%- endblock body_title_elem %}
         {% block content %}{% endblock %}
         <hr>

--- a/webplatformcompat/templates/webplatformcompat/browse.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/browse.jinja2
@@ -276,6 +276,7 @@
 {% raw %}
 <h2>Feature {{{nameDefaultHTML}}}</h2>
 <p><em>back to {{#link-to 'features'}}Features{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
+<p class="lead"><strong><a {{bind-attr href=viewUrl}}>View this feature with related data</a>.</strong></p>
 <dl>
   <dt>Id</dt>
   <dd>{{id}}</dd>

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -21,7 +21,7 @@
         <a href="{{trans_str(spec.uri) ~ trans_str(section.subpath)}}">
           {{trans_span(spec.name)}}
           <br>
-          <small>{{trans_span(section.name)}}</small>
+          <small>{{trans_span(section.number)}} {{trans_span(section.name)}}</small>
         </a>
       </td>
       <td>
@@ -44,13 +44,12 @@
 {% endif %}
 
 <h2>Browser compatability</h2>
-{%- set footnotes = [] %}
 {%- for tab in meta['compat_table']['tabs'] %}
 
 
 <h3>{{trans_str(tab['name'])}}</h3>
 <table class="compat-table">
-  <tbody>
+  <thead>
     <tr>
       <th>Feature</th>
       {%- for browser_id in tab['browsers'] %}
@@ -60,6 +59,8 @@
       {%- endfor %}
 
     </tr>
+  </thead>
+  <tbody>
     {%- for feature_id, browser_map in meta['compat_table']['supports'].items() %}
     {%- if feature_id != data['id'] %}
     {%- set feature = collection['features'][feature_id] %}
@@ -77,8 +78,15 @@
           {%- set version = collection['versions'][version_id] %}
           {%- if not loop.first %}<br>{% endif %}
           {%- if version.version %}
+          {%- if version.release_notes_uri %}
 
-        {{ version.version }}{% if support.support != 'yes'%} ({{support.support}}){% endif %}
+        <a href="{{trans_str(version.release_notes_uri)}}" title="Release Notes">{{version.version}}</a>
+          {%- else %}
+
+        {{version.version}}
+          {%- endif %}
+
+          {%- if support.support != 'yes'%} ({{support.support}}){% endif %}
           {%- else %}
 
         ({{ support.support }})
@@ -89,13 +97,13 @@
           {%- endif %}
           {%- if support.note %}
 
-        <br>({{support.note}})
+        ({{trans_span(support.note)}})
           {%- endif %}
           {%- if support.footnote %}
             {%- set footnum = meta['compat_table']['footnotes'][support_id] %}
             [<a
-              id="browsercompat-{{data['id']}}-footnote-{{footnum}}-back"
-              href="#browsercompat-{{data['id']}}-footnote-{{footnum}}">{{footnum}}</a>]
+              id="wpc-compat-{{data['id']}}-footnote-{{footnum}}-back"
+              href="#wpc-compat-{{data['id']}}-footnote-{{footnum}}">{{footnum}}</a>]
           {%- endif %}
         {%- else %}
 
@@ -116,13 +124,17 @@
 
 {%- endfor %}
 
-{%- for support_id, footnum in meta['compat_table']['footnotes'] | dictsort(by='value') %}
-{%- set support=collection['supports'][support_id] %}
-<p id="browsercompat-{{data['id']}}-footnote-{{footnum}}">
-  <a href="#browsercompat-{{data['id']}}-footnote-{{footnum}}-back">[{{footnum}}]</a>
-  {{trans_span(support.footnote)}}
-</p>
-{% endfor %}
+{% if meta['compat_table']['footnotes'] %}
+<div id="wpc-compat-{{data.id}}-footnotes">
+  {%- for support_id, footnum in meta['compat_table']['footnotes'] | dictsort(by='value') %}
+  {%- set support=collection['supports'][support_id] %}
+  <p id="browsercompat-{{data['id']}}-footnote-{{footnum}}">
+    <a href="#browsercompat-{{data['id']}}-footnote-{{footnum}}-back">[{{footnum}}]</a>
+    {{trans_span(support.footnote)}}
+  </p>
+  {%- endfor %}
+</div>
+{% endif %}
 
 </section>
 <section class="webplatformcompat-feature-meta" lang="{{lang}}">

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -1,0 +1,109 @@
+<section class="webplatformcompat-feature" lang="{{lang}}" data-type="{{data['type']}}" data-id="{{data['id']}}">
+<h2>Specifications</h2>
+{% if collection['specifications'] %}
+<table class="specifications-table">
+  <thead>
+    <tr>
+      <th>Specification</th>
+      <th>Status</th>
+      <th>Comment</th>
+    </tr>
+  </thead>
+  <tbody>
+  {%- for section_id in data['links']['sections'] %}
+    {%- set section = collection['sections'][section_id] %}
+    {%- set spec = collection['specifications'][section['links']['specification']] %}
+    {%- set maturity = collection['maturities'][spec['links']['maturity']] %}
+    {%- set mat_class = "maturity-" ~ maturity.slug %}
+
+    <tr>
+      <td>
+        <a href="{{trans_str(spec.uri) ~ trans_str(section.subpath)}}">
+          {{trans_span(spec.name)}}
+          <br>
+          <small>{{trans_span(section.name)}}</small>
+        </a>
+      </td>
+      <td>
+        {{trans_span(maturity.name, class=mat_class)}}
+      </td>
+      <td>
+        {%- if section.note %}
+        {{trans_span(section.note)}}
+        {% endif %}
+
+      </td>
+    </tr>
+  {%- endfor %}
+
+  </tbody>
+</table>
+{% else %}
+<i>No specifications</i>
+{% endif %}
+
+<h2>Browser compatability</h2>
+{%- for tab in meta['compat_table']['tabs'] %}
+
+
+<h3>{{trans_str(tab['name'])}}</h3>
+<table class="compat-table">
+  <tbody>
+    <tr>
+      <th>Feature</th>
+      {%- for browser_id in tab['browsers'] %}
+      {%- set browser = collection['browsers'][browser_id] %}
+
+      <th>{{trans_span(browser.name)}}</th>
+      {%- endfor %}
+
+    </tr>
+    {%- for feature_id, browser_map in meta['compat_table']['supports'].items() %}
+    {%- set feature = collection['features'][feature_id] %}
+
+    <tr>
+      <td>{{trans_span(feature.name)}}</td>
+      {%- for browser_id in tab['browsers'] %}
+        {%- set browser = collection['browsers'][browser_id] %}
+        {%- set supports = browser_map[browser_id] %}
+
+      <td>
+        {%- for support_id in supports %}
+          {%- set support = collection['supports'][support_id] %}
+          {%- set version_id = support['links']['version'] %}
+          {%- set version = collection['versions'][version_id] %}
+          {%- if not loop.first %}<br>{% endif %}
+          {%- if version.version %}
+
+        {{ version.version }}
+          {%- else %}
+
+        {{ support.support }}
+          {%- endif %}
+        {%- endfor %}
+
+      </td>
+      {%- endfor %}
+
+    </tr>
+    {%- endfor %}
+
+  </tbody>
+</table>
+{%- endfor %}
+
+</section>
+<section class="webplatformcompat-feature-meta" lang="{{lang}}">
+<p><em>Showing language "{{lang}}". Other languages:</em></p>
+<ul>
+{% for l in meta['compat_table']['languages'] %}
+  <li><a href="/api/v1/view_features/{{data['id']}}?format=html&lang={{l}}">{{l}}</a></li>
+{% endfor %}
+</ul>
+</section>
+{#
+<pre>meta: {{meta|pprint}}</pre>
+<pre>features: {{features|pprint}}</pre>
+<pre>collection: {{collection|pprint}}</pre>
+<pre>language: {{lang}}</pre>
+#}

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -1,6 +1,6 @@
 <section class="webplatformcompat-feature" lang="{{lang}}" data-type="{{data['type']}}" data-id="{{data['id']}}">
 <h2>Specifications</h2>
-{% if collection['specifications'] %}
+{% if data['links']['sections'] %}
 <table class="specifications-table">
   <thead>
     <tr>
@@ -39,6 +39,7 @@
   </tbody>
 </table>
 {% else %}
+
 <i>No specifications</i>
 {% endif %}
 
@@ -60,6 +61,7 @@
 
     </tr>
     {%- for feature_id, browser_map in meta['compat_table']['supports'].items() %}
+    {%- if feature_id != data['id'] %}
     {%- set feature = collection['features'][feature_id] %}
 
     <tr>
@@ -97,17 +99,21 @@
           {%- endif %}
         {%- else %}
 
-          ?
+        ?
         {%- endfor %}
 
       </td>
       {%- endfor %}
 
     </tr>
+    {%- endif %}
     {%- endfor %}
 
   </tbody>
 </table>
+{%- else %}
+<i>No compatability data</i>
+
 {%- endfor %}
 
 {%- for support_id, footnum in meta['compat_table']['footnotes'] | dictsort(by='value') %}
@@ -126,6 +132,15 @@
   <li><a href="/api/v1/view_features/{{data['id']}}?format=html&lang={{l}}">{{l}}</a></li>
 {% endfor %}
 </ul>
+
+{%- set pagination =  meta['compat_table']['pagination']['linked.features'] %}
+{%- if pagination['next'] or pagination['previous'] %}
+<p>{{pagination['count']}} features total (
+{%- if pagination['previous'] %}<a href="{{pagination['previous']}}">previous page</a>{% endif%}
+{%- if pagination['next'] and pagination['previous'] %}, {% endif %}
+{%- if pagination['next'] %}<a href="{{pagination['next']}}">next page</a>{% endif %}).
+{%- endif %}
+
 </section>
 {#
 <pre>meta: {{meta|pprint}}</pre>

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -43,6 +43,7 @@
 {% endif %}
 
 <h2>Browser compatability</h2>
+{%- set footnotes = [] %}
 {%- for tab in meta['compat_table']['tabs'] %}
 
 
@@ -75,11 +76,28 @@
           {%- if not loop.first %}<br>{% endif %}
           {%- if version.version %}
 
-        {{ version.version }}
+        {{ version.version }}{% if support.support != 'yes'%} ({{support.support}}){% endif %}
           {%- else %}
 
-        {{ support.support }}
+        ({{ support.support }})
           {%- endif %}
+          {%- if support.prefix and support.prefix_mandatory %}
+
+        <code>{{support.prefix}}</code>
+          {%- endif %}
+          {%- if support.note %}
+
+        <br>({{support.note}})
+          {%- endif %}
+          {%- if support.footnote %}
+            {%- set footnum = meta['compat_table']['footnotes'][support_id] %}
+            [<a
+              id="browsercompat-{{data['id']}}-footnote-{{footnum}}-back"
+              href="#browsercompat-{{data['id']}}-footnote-{{footnum}}">{{footnum}}</a>]
+          {%- endif %}
+        {%- else %}
+
+          ?
         {%- endfor %}
 
       </td>
@@ -91,6 +109,14 @@
   </tbody>
 </table>
 {%- endfor %}
+
+{%- for support_id, footnum in meta['compat_table']['footnotes'] | dictsort(by='value') %}
+{%- set support=collection['supports'][support_id] %}
+<p id="browsercompat-{{data['id']}}-footnote-{{footnum}}">
+  <a href="#browsercompat-{{data['id']}}-footnote-{{footnum}}-back">[{{footnum}}]</a>
+  {{trans_span(support.footnote)}}
+</p>
+{% endfor %}
 
 </section>
 <section class="webplatformcompat-feature-meta" lang="{{lang}}">

--- a/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
@@ -1,0 +1,138 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}Sample View for Feature{% endblock %}
+
+{% block body_title %}Sample View for Feature{% endblock %}
+
+{% block content %}
+<p>
+  Original data available on: <br>
+  <a id="mdn_link" href="https://developer.mozilla.org/">
+    https://developer.mozilla.org/
+  </a>
+</p>
+
+<p id="wpc_pagination"></p>
+
+<h2>Specifications</h2>
+<div id="wpc_specifications">
+  <p><i>Loading...</i></p>
+</div>
+
+<h2>Browser compatability</h2>
+<div id="wpc_tables">
+  <p><i>Loading...</i></p>
+</div>
+
+<h2>Languages</h2>
+<p>
+    The data may include translations of items such as feature names,
+    specification statuses, release notes URIs, etc.  Available languages:</p>
+<div id="wpc_languages">
+  <ul>
+    <li><i>Loading...</i></li>
+  </ul>
+</div>
+
+<h2>Raw Data</h2>
+<p>
+  This is the raw JSON-API data returned from
+  <code>
+    <a id="wpc_uri" href="/api/v1/view_features/{{feature_id}}">
+      /api/v1/view_features/{{feature_id}}
+    </a>
+  </code>
+</p>
+
+<div id="wpc_data">
+  <p><i>Loading...</i></p>
+</div>
+{% endblock content %}
+
+{% block body_js_extra %}
+<script>
+function load_tables(resources, lang) {
+    var spec_table, browser_tables, langs, pagination;
+
+    spec_table = WPC.generate_specification_table(resources, lang);
+    if (spec_table) {
+    $("#wpc_specifications").html(spec_table);
+    } else {
+    $("#wpc_specifications").html("<p><i>No specifications</i></p>");
+    }
+
+    browser_tables = WPC.generate_browser_tables(resources, lang);
+    if (browser_tables) {
+    $("#wpc_tables").html(browser_tables);
+    } else {
+    $("#wpc_tables").html("<p><i>No features</i></p>");
+    }
+
+    langs = "<ul>";
+    $.each(resources.meta.compat_table.languages, function(index, value) {
+        langs += (
+            "<li><a href=\"#\" onclick=\"load_tables(resources, '" +
+            value + "')\" >" + value + "</a>");
+        if (value === lang) {
+            langs += " (<strong>current</strong>)";
+        }
+        langs += "</li>";
+    });
+    langs += '</ul>';
+    $("#wpc_languages").html($(langs));
+
+    mdn_uri = WPC.trans_str(resources.data.mdn_uri, lang);
+    if (!mdn_uri) {
+        mdn_uri = "https://developer.mozilla.org/";
+    }
+    $("#mdn_link").attr("href", mdn_uri);
+    $("#mdn_link").text(mdn_uri);
+
+    pagination = resources.meta.compat_table.pagination["linked.features"];
+    if (pagination && (pagination.next || pagination.previous)) {
+        pageText = (
+            "<p id=\"wpc_pagination\">There are " + pagination.count +
+            " sub-features, which is too many to display on one page." +
+            " Go to the ");
+        if (pagination.next) {
+            pageText += ("<a href=\"#\" onclick=\"load_json('" +
+                pagination.next + "')\">next page</a>");
+        }
+        if (pagination.next && pagination.previous) {
+            pageText += " or the ";
+        }
+        if (pagination.previous) {
+            pageText += ("<a href=\"#\" onclick=\"load_json('" +
+                pagination.previous + "')\">previous page</a>");
+        }
+        pageText += ".</p>";
+        $("#wpc_pagination").html($(pageText));
+    }
+
+    return true;
+};
+
+function load_json(uri) {
+    $.getJSON(uri).done(function( data ) {
+        var resources, json_dump, title;
+        json_dump = $("<pre>").text(JSON.stringify(data, null, "  "));
+        $("#wpc_data").html(json_dump);
+        window.resources = resources = WPC.parse_resources(data);
+
+        title = "Sample View for Feature '" + resources.data.name.en + "'";
+        document.title = title;
+        $("#body_title").html(title);
+
+        $("#wpc_uri").attr("href", uri);
+        $("#wpc_uri").text(uri);
+
+        load_tables(window.resources, "en");
+    });
+};
+
+$( document ).ready(function () {
+    var uri = '/api/v1/view_features/{{feature_id}}';
+    load_json(uri);
+});
+</script>
+{% endblock %}

--- a/webplatformcompat/tests/test_drf_fields.py
+++ b/webplatformcompat/tests/test_drf_fields.py
@@ -49,6 +49,9 @@ class TestTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
         # will raise an error
         self.assertEqual("display", self.ttf.from_native('"display"'))
 
+    def test_from_native_null(self):
+        self.assertEqual(None, self.ttf.from_native(None))
+
     def test_from_native_bad_json(self):
         # Converting from serialized form, bad JSON becomes ValidationError
         bad_json = "{'quotes': 'wrong ones'}"

--- a/webplatformcompat/tests/test_drf_fields.py
+++ b/webplatformcompat/tests/test_drf_fields.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for `web-platform-compat` fields module."""
 
+from collections import OrderedDict
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -18,6 +20,16 @@ class SharedTranslatedTextFieldTests(object):
         # Converting to serializable form, dicts are passed through
         data = {"key": "value"}
         self.assertEqual(data, self.ttf.to_native(data))
+
+    def test_to_native_sorted_dict(self):
+        # Converting to serializable form, dict is sorted, English first
+        data = {'es': 'Spanish', 'en': 'English', 'ru': 'Russian'}
+        expected = OrderedDict([
+            ('en', 'English'),
+            ('es', 'Spanish'),
+            ('ru', 'Russian')])
+        self.assertEqual(expected, self.ttf.to_native(data))
+        self.assertEqual(expected.keys(), self.ttf.to_native(data).keys())
 
     def test_from_native_falsy(self):
         # Converting from serialized form, false values are None

--- a/webplatformcompat/tests/test_helpers.py
+++ b/webplatformcompat/tests/test_helpers.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Tests for jingo/jinja2 helper functions and filters."""
+
+from __future__ import unicode_literals
+
+from jinja2 import Markup
+
+from webplatformcompat.helpers import pick_translation, trans_span, trans_str
+
+from .base import TestCase
+
+
+class TestPickTranslation(TestCase):
+    def setUp(self):
+        self.context = {'lang': 'en'}
+        self.trans_obj = {
+            'en': 'English',
+            'es': 'Español',
+        }
+
+    def test_empty(self):
+        result = pick_translation(self.context, {})
+        self.assertEqual(('', None), result)
+
+    def test_canonical(self):
+        result = pick_translation(self.context, 'canonical string')
+        self.assertEqual(('canonical string', None), result)
+
+    def test_canonical_html(self):
+        result = pick_translation(self.context, '<input>')
+        self.assertEqual(('<input>', None), result)
+
+    def test_match_en(self):
+        result = pick_translation(self.context, self.trans_obj)
+        self.assertEqual(('English', 'en'), result)
+
+    def test_match_es(self):
+        self.context['lang'] = 'es'
+        result = pick_translation(self.context, self.trans_obj)
+        self.assertEqual(('Español', 'es'), result)
+
+    def test_no_match(self):
+        self.context['lang'] = 'ru'
+        result = pick_translation(self.context, self.trans_obj)
+        self.assertEqual(('English', 'en'), result)
+
+
+class TestTransSpan(TestCase):
+    def setUp(self):
+        self.context = {'lang': 'en'}
+        self.trans_obj = {
+            'en': 'English',
+            'es': 'Español',
+        }
+
+    def test_empty(self):
+        result = trans_span(self.context, {})
+        self.assertEqual(Markup(''), result)
+
+    def test_canonical(self):
+        result = trans_span(self.context, 'canonical string')
+        self.assertEqual('<code>canonical string</code>', result)
+        self.assertIsInstance(result, Markup)
+
+    def test_canonical_html(self):
+        result = trans_span(self.context, '<input>')
+        self.assertEqual('<code>&lt;input&gt;</code>', result)
+        self.assertIsInstance(result, Markup)
+
+    def test_match_en(self):
+        result = trans_span(self.context, self.trans_obj)
+        self.assertEqual('English', result)
+        self.assertIsInstance(result, Markup)
+
+    def test_match_es(self):
+        self.context['lang'] = 'es'
+        result = trans_span(self.context, self.trans_obj)
+        self.assertEqual('Español', result)
+        self.assertIsInstance(result, Markup)
+
+    def test_no_match(self):
+        self.context['lang'] = 'ru'
+        result = trans_span(self.context, self.trans_obj)
+        self.assertEqual('<span lang="en">English</span>', result)
+        self.assertIsInstance(result, Markup)
+
+
+class TestTransStr(TestCase):
+    def setUp(self):
+        self.context = {'lang': 'en'}
+        self.trans_obj = {
+            'en': 'English',
+            'es': 'Español',
+        }
+
+    def test_empty(self):
+        result = trans_str(self.context, {})
+        self.assertEqual('', result)
+
+    def test_canonical(self):
+        result = trans_str(self.context, 'canonical string')
+        self.assertEqual('canonical string', result)
+
+    def test_canonical_html(self):
+        result = trans_str(self.context, '<input>')
+        self.assertEqual('<input>', result)
+
+    def test_match_en(self):
+        result = trans_str(self.context, self.trans_obj)
+        self.assertEqual('English', result)
+
+    def test_match_es(self):
+        self.context['lang'] = 'es'
+        result = trans_str(self.context, self.trans_obj)
+        self.assertEqual('Español', result)
+
+    def test_no_match(self):
+        self.context['lang'] = 'ru'
+        result = trans_str(self.context, self.trans_obj)
+        self.assertEqual('English', result)

--- a/webplatformcompat/tests/test_views.py
+++ b/webplatformcompat/tests/test_views.py
@@ -46,3 +46,8 @@ class TestViews(TestCase):
         }
         actual = loads(response.content.decode('utf-8'))
         self.assertDataEqual(expected, actual)
+
+    def test_view_feature(self):
+        response = self.client.get(
+            reverse('view_feature', kwargs={'feature_id': 1}))
+        self.assertEqual(response.status_code, 200)

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -305,6 +305,7 @@ class TestViewFeatureViewSet(APITestCase):
                         },
                     },
                     "languages": ['en'],
+                    "footnotes": {},
                 }
             }
         }
@@ -375,6 +376,73 @@ class TestViewFeatureViewSet(APITestCase):
         }
         actual_pagination = actual_json['meta']['compat_table']['pagination']
         self.assertDataEqual(expected_pagination, actual_pagination)
+
+    def test_important_versions(self):
+        feature = self.create(Feature, slug='feature')
+        browser = self.create(Browser, slug='browser')
+        v1 = self.create(Version, browser=browser, version='1')
+        support = {
+            'support': 'yes',
+            'prefix': '--pre',
+            'prefix_mandatory': True,
+            'alternate_name': 'future',
+            'alternate_mandatory': True,
+            'requires_config': 'feature=Yes',
+            'default_config': 'feature=No',
+            'protected': False,
+            'note': {'en': 'note'},
+            'footnote': {'en': 'footnote'},
+        }
+        s1 = self.create(Support, version=v1, feature=feature, **support)
+
+        v2 = self.create(Version, browser=browser, version='2')
+        support['prefix_mandatory'] = False
+        s2 = self.create(Support, version=v2, feature=feature, **support)
+
+        v3 = self.create(Version, browser=browser, version='3')
+        support['prefix'] = ''
+        s3 = self.create(Support, version=v3, feature=feature, **support)
+
+        v4 = self.create(Version, browser=browser, version='4')
+        support['alternate_mandatory'] = False
+        s4 = self.create(Support, version=v4, feature=feature, **support)
+
+        v5 = self.create(Version, browser=browser, version='5')
+        support['alternate_name'] = ''
+        s5 = self.create(Support, version=v5, feature=feature, **support)
+
+        # BORING VERSION
+        v51 = self.create(Version, browser=browser, version='5.1')
+        self.create(Support, version=v51, feature=feature, **support)
+
+        v6 = self.create(Version, browser=browser, version='6')
+        support['default_config'] = 'feature=Yes'
+        s6 = self.create(Support, version=v6, feature=feature, **support)
+
+        v7 = self.create(Version, browser=browser, version='7')
+        support['protected'] = True
+        s7 = self.create(Support, version=v7, feature=feature, **support)
+
+        v8 = self.create(Version, browser=browser, version='8')
+        support['note']['es'] = 'el note'
+        s8 = self.create(Support, version=v8, feature=feature, **support)
+
+        v9 = self.create(Version, browser=browser, version='9')
+        support['footnote'] = None
+        s9 = self.create(Support, version=v9, feature=feature, **support)
+
+        url = reverse('viewfeatures-detail', kwargs={'pk': feature.pk})
+        response = self.client.get(url)
+        actual_json = loads(response.content.decode('utf-8'))
+        expected_supports = {
+            str(feature.pk): {
+                str(browser.pk): [
+                    str(s1.pk), str(s2.pk), str(s3.pk), str(s4.pk),
+                    str(s5.pk), str(s6.pk), str(s7.pk), str(s8.pk),
+                    str(s9.pk)
+                ]}}
+        actual_supports = actual_json['meta']['compat_table']['supports']
+        self.assertDataEqual(expected_supports, actual_supports)
 
     def test_get_documented(self):
         """Get the viewfeature with the hand-coded values for docs.
@@ -1498,6 +1566,7 @@ class TestViewFeatureViewSet(APITestCase):
                         },
                     },
                     "languages": ['en', 'ja', 'jp'],
+                    "footnotes": {},
                 }
             }
         }
@@ -1580,7 +1649,7 @@ multipage/sections.html#the-address-element">
     <tr>
       <td><span lang="en">Basic support</span></td>
       <td>
-        yes
+        (yes)
       </td>
       <td>
         1.0
@@ -1613,22 +1682,22 @@ multipage/sections.html#the-address-element">
     <tr>
       <td><span lang="en">Basic support</span></td>
       <td>
-        yes
+        (yes)
       </td>
       <td>
         1.0
       </td>
       <td>
-        yes
+        (yes)
       </td>
       <td>
-        yes
+        (yes)
       </td>
       <td>
-        yes
+        (yes)
       </td>
       <td>
-        yes
+        (yes)
       </td>
     </tr>
   </tbody>

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -288,7 +288,7 @@ class TestViewFeatureViewSet(APITestCase):
                 "compat_table": {
                     "tabs": [
                         {
-                            "name": {"en": "Desktop"},
+                            "name": {"en": "Desktop Browsers"},
                             "browsers": [str(browser.pk)]
                         },
                     ],
@@ -304,6 +304,7 @@ class TestViewFeatureViewSet(APITestCase):
                             "count": 0,
                         },
                     },
+                    "languages": ['en'],
                 }
             }
         }
@@ -1439,7 +1440,7 @@ class TestViewFeatureViewSet(APITestCase):
                     "tabs": [
                         {
                             "name": {
-                                "en": "Desktop"
+                                "en": "Desktop Browsers"
                             },
                             "browsers": [
                                 str(browser_chrome_1.pk),
@@ -1451,7 +1452,7 @@ class TestViewFeatureViewSet(APITestCase):
                         },
                         {
                             "name": {
-                                "en": "Mobile"
+                                "en": "Mobile Browsers"
                             },
                             "browsers": [
                                 str(browser_android_6.pk),
@@ -1496,8 +1497,150 @@ class TestViewFeatureViewSet(APITestCase):
                             "count": 1,
                         },
                     },
+                    "languages": ['en', 'ja', 'jp'],
                 }
             }
         }
         actual_json = loads(response.content.decode('utf-8'))
         self.assertDataEqual(expected_json, actual_json)
+
+        response = self.client.get(url + '.html')
+        expected = """\
+<section class="webplatformcompat-feature" lang="en-us" data-type="features"\
+ data-id="%(f_id)s">
+<h2>Specifications</h2>
+<table class="specifications-table">
+  <thead>
+    <tr>
+      <th>Specification</th>
+      <th>Status</th>
+      <th>Comment</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="http://www.whatwg.org/specs/web-apps/current-work/\
+multipage/sections.html#the-address-element">
+          <span lang="en">WHATWG HTML Living Standard</span>
+          <br>
+          <small><span lang="en">The address element</span></small>
+        </a>
+      </td>
+      <td>
+        <span class="maturity-Living" lang="en">Living Standard</span>
+      </td>
+      <td>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="http://www.w3.org/TR/html5/sections.html#the-address-element">
+          <span lang="en">HTML5</span>
+          <br>
+          <small><span lang="en">The address element</span></small>
+        </a>
+      </td>
+      <td>
+        <span class="maturity-PR" lang="en">Proposed Recommendation</span>
+      </td>
+      <td>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="http://www.w3.org/TR/html401/struct/global.html#h-7.5.6">
+          <span lang="en">HTML 4.01 Specification</span>
+          <br>
+          <small><span lang="en">The ADDRESS element</span></small>
+        </a>
+      </td>
+      <td>
+        <span class="maturity-REC" lang="en">Recommendation</span>
+      </td>
+      <td>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Browser compatability</h2>
+
+<h3>Desktop Browsers</h3>
+<table class="compat-table">
+  <tbody>
+    <tr>
+      <th>Feature</th>
+      <th><span lang="en">Chrome</span></th>
+      <th><span lang="en">Firefox</span></th>
+      <th><span lang="en">Internet Explorer</span></th>
+      <th><span lang="en">Opera</span></th>
+      <th><span lang="en">Safari</span></th>
+    </tr>
+    <tr>
+      <td><span lang="en">Basic support</span></td>
+      <td>
+        yes
+      </td>
+      <td>
+        1.0
+      </td>
+      <td>
+        1.0
+      </td>
+      <td>
+        5.12
+      </td>
+      <td>
+        1.0
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Mobile Browsers</h3>
+<table class="compat-table">
+  <tbody>
+    <tr>
+      <th>Feature</th>
+      <th><span lang="en">Android</span></th>
+      <th><span lang="en">Firefox Mobile</span></th>
+      <th><span lang="en">IE Mobile</span></th>
+      <th><span lang="en">Opera Mini</span></th>
+      <th><span lang="en">Opera Mobile</span></th>
+      <th><span lang="en">Safari Mobile</span></th>
+    </tr>
+    <tr>
+      <td><span lang="en">Basic support</span></td>
+      <td>
+        yes
+      </td>
+      <td>
+        1.0
+      </td>
+      <td>
+        yes
+      </td>
+      <td>
+        yes
+      </td>
+      <td>
+        yes
+      </td>
+      <td>
+        yes
+      </td>
+    </tr>
+  </tbody>
+</table>
+</section>
+<section class="webplatformcompat-feature-meta" lang="en-us">
+<p><em>Showing language "en-us". Other languages:</em></p>
+<ul>
+  <li><a href="/api/v1/view_features/%(f_id)s?format=html&lang=en">en</a></li>
+  <li><a href="/api/v1/view_features/%(f_id)s?format=html&lang=ja">ja</a></li>
+  <li><a href="/api/v1/view_features/%(f_id)s?format=html&lang=jp">jp</a></li>
+</ul>
+</section>
+""" % {'f_id': feature_816.id}
+        self.assertDataEqual(expected, response.content.decode('utf-8'))

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -1594,7 +1594,8 @@ class TestViewFeatureViewSet(APITestCase):
 multipage/sections.html#the-address-element">
           <span lang="en">WHATWG HTML Living Standard</span>
           <br>
-          <small><span lang="en">The address element</span></small>
+          <small><span lang="en">4.3.10</span> \
+<span lang="en">The address element</span></small>
         </a>
       </td>
       <td>
@@ -1608,7 +1609,8 @@ multipage/sections.html#the-address-element">
         <a href="http://www.w3.org/TR/html5/sections.html#the-address-element">
           <span lang="en">HTML5</span>
           <br>
-          <small><span lang="en">The address element</span></small>
+          <small><span lang="en">4.3.9</span> \
+<span lang="en">The address element</span></small>
         </a>
       </td>
       <td>
@@ -1622,7 +1624,8 @@ multipage/sections.html#the-address-element">
         <a href="http://www.w3.org/TR/html401/struct/global.html#h-7.5.6">
           <span lang="en">HTML 4.01 Specification</span>
           <br>
-          <small><span lang="en">The ADDRESS element</span></small>
+          <small><span lang="en">7.5.6</span> \
+<span lang="en">The ADDRESS element</span></small>
         </a>
       </td>
       <td>
@@ -1638,7 +1641,7 @@ multipage/sections.html#the-address-element">
 
 <h3>Desktop Browsers</h3>
 <table class="compat-table">
-  <tbody>
+  <thead>
     <tr>
       <th>Feature</th>
       <th><span lang="en">Chrome</span></th>
@@ -1647,6 +1650,8 @@ multipage/sections.html#the-address-element">
       <th><span lang="en">Opera</span></th>
       <th><span lang="en">Safari</span></th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><span lang="en">Basic support</span></td>
       <td>
@@ -1670,7 +1675,7 @@ multipage/sections.html#the-address-element">
 
 <h3>Mobile Browsers</h3>
 <table class="compat-table">
-  <tbody>
+  <thead>
     <tr>
       <th>Feature</th>
       <th><span lang="en">Android</span></th>
@@ -1680,6 +1685,8 @@ multipage/sections.html#the-address-element">
       <th><span lang="en">Opera Mobile</span></th>
       <th><span lang="en">Safari Mobile</span></th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <td><span lang="en">Basic support</span></td>
       <td>
@@ -1703,6 +1710,7 @@ multipage/sections.html#the-address-element">
     </tr>
   </tbody>
 </table>
+
 </section>
 <section class="webplatformcompat-feature-meta" lang="en-us">
 <p><em>Showing language "en-us". Other languages:</em></p>
@@ -1714,3 +1722,4 @@ multipage/sections.html#the-address-element">
 </section>
 """ % {'f_id': feature_816.id}
         self.assertDataEqual(expected, response.content.decode('utf-8'))
+        self.assertContains(response, expected, html=True)

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -1533,6 +1533,7 @@ class TestViewFeatureViewSet(APITestCase):
                         }
                     ],
                     "supports": {
+                        str(feature_816.pk): {},
                         str(feature_row_191.pk): {
                             str(browser_chrome_1.pk): [
                                 str(support_chrome_358.pk)],

--- a/webplatformcompat/urls.py
+++ b/webplatformcompat/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, patterns, url
 from django.views.generic.base import RedirectView
 from webplatformcompat.routers import router
 
-from .views import RequestView
+from .views import RequestView, ViewFeature
 
 
 webplatformcompat_urlpatterns = patterns(
@@ -17,4 +17,7 @@ webplatformcompat_urlpatterns = patterns(
         namespace='rest_framework')),
     url(r'^api/$', RedirectView.as_view(url='/api/v1/', permanent=False)),
     url(r'^api/v1/', include(router.urls)),
+    url(r'^view_feature/(?P<feature_id>\d+)(.html)?$', ViewFeature.as_view(
+        template_name='webplatformcompat/feature.js.jinja2'),
+        name='view_feature'),
 )

--- a/webplatformcompat/views.py
+++ b/webplatformcompat/views.py
@@ -10,3 +10,11 @@ class RequestContextMixin(object):
 
 class RequestView(RequestContextMixin, TemplateView):
     pass
+
+
+class ViewFeature(RequestContextMixin, TemplateView):
+
+    def get_context_data(self, **kwargs):
+        ctx = super(ViewFeature, self).get_context_data(**kwargs)
+        ctx['feature_id'] = self.kwargs['feature_id']
+        return ctx

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -14,7 +14,7 @@ from .mixins import PartialPutMixin
 from .models import (
     Browser, Feature, Maturity, Section, Specification, Support, Version)
 from .parsers import JsonApiParser
-from .renderers import JsonApiRenderer
+from .renderers import JsonApiRenderer, JsonApiTemplateHTMLRenderer
 from .serializers import (
     BrowserSerializer, FeatureSerializer, MaturitySerializer,
     SectionSerializer, SpecificationSerializer, SupportSerializer,
@@ -174,6 +174,9 @@ class ViewFeaturesViewSet(CachedViewMixin, ReadOnlyModelViewSet):
     model = Feature
     serializer_class = ViewFeatureSerializer
     filter_fields = ('slug',)
+    renderer_classes = (
+        JsonApiRenderer, BrowsableAPIRenderer, JsonApiTemplateHTMLRenderer)
+    template_name = 'webplatformcompat/feature.basic.jinja2'
 
     def get_serializer_class(self):
         """Return the list serializer when needed."""

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -31,6 +31,8 @@ MEMCACHE_SERVERS - semicolon-separated list of memcache servers
 MEMCACHE_USERNAME - username for memcache servers
 MEMCACHE_PASSWORD - password for memcache servers
 USE_DRF_INSTANCE_CACHE - 1 to enable, 0 to disable, default enabled
+DRF_INSTANCE_CACHE_POPULATE_COLD - 1 to recursively populate a cold cache on
+  updates, 0 to be eventually consistent, default enabled
 SECRET_KEY - Overrides SECRET_KEY
 SECURE_PROXY_SSL_HEADER - "HTTP_X_FORWARDED_PROTOCOL,https" to enable
 STATIC_ROOT - Overrides STATIC_ROOT
@@ -236,3 +238,5 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 # DRF Cached Instances - avoid DB reads for Django REST Framework
 USE_DRF_INSTANCE_CACHE = (
     environ.get('USE_DRF_INSTANCE_CACHE', '1') not in (0, '0'))
+DRF_INSTANCE_CACHE_POPULATE_COLD = (
+    environ.get('DRF_INSTANCE_CACHE_POPULATE_COLD', '1') not in (0, '0'))


### PR DESCRIPTION
*This builds on PR #18 - you may want to merge that first*

These changes add HTML views of features and related data.  This code has been applied to the Heroku instances.

The HTML variant of the API view_feature constructs the HTML on the server side:

https://browsercompat.herokuapp.com/api/v1/view_features/741.html

The JS-enabled view downloads the JSON API representation, constructs the HTML version, and injects it into the DOM:

https://browsercompat.herokuapp.com/view_feature/741

This change makes it easier to visually confirm that an MDN page has been imported correctly:

https://developer.mozilla.org/en-US/docs/Web/CSS/float#Specifications