### PR TITLE
Fix bug 1123935 - Add CORS middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,6 @@ drf-cached-instances==0.2.0
 
 # Better HTTP Client for tools
 requests==2.4.3
+
+# CORS headers in middleware
+git+git://github.com/ottoyiu/django-cors-headers@5d5eeccf7ce#egg=django-cors-headers

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'corsheaders',
     'django_extensions',
     'django_nose',
     'mptt',
@@ -94,8 +95,10 @@ if environ.get('EXTRA_INSTALLED_APPS'):
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'corsheaders.middleware.CorsPostCsrfMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -240,3 +243,7 @@ USE_DRF_INSTANCE_CACHE = (
     environ.get('USE_DRF_INSTANCE_CACHE', '1') not in (0, '0'))
 DRF_INSTANCE_CACHE_POPULATE_COLD = (
     environ.get('DRF_INSTANCE_CACHE_POPULATE_COLD', '1') not in (0, '0'))
+
+# CORS Middleware
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
The [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) (CORS) mechanism includes server headers that inform a web client if a HTTP request should be treated as a same-origin request.  This PR adds [django-cors-headers](https://github.com/ottoyiu/django-cors-headers) middleware to add an allow-all header ``Access-Control-Allow-Origin: *`` to responses.  There are some recent changes to support SSL that require using the master head instead of the PyPI version.

Feature request filed as [Bug 1123935](https://bugzil.la/1123935).  I suggest @stephaniehobson for code review.