### PR TITLE
bug 1132269 - Various importer fixes

### DIFF
--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -47,7 +47,7 @@ doc = other_text other_section* spec_section? compat_section?
 # Sections that we don't care about
 other_text = ~r".*?(?=<h2)"s
 other_section = _ !(spec_h2 / compat_h2) other_h2 _ other_text
-other_h2 = "<h2 " _ attrs? _ ">" _ bare_text _ "</h2>"
+other_h2 = "<h2 " _ attrs? _ ">" _ ~r"(?P<content>.*?(?=</h2>))"s _ "</h2>"
 last_section = _ other_h2 _ ~r".*(?!=<h2)"s
 
 #

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -68,21 +68,21 @@ spec_tbody = "<tbody>"
 spec_body = spec_rows "</tbody>"
 spec_rows = spec_row+
 spec_row = tr_open _ specname_td _ spec2_td _ specdesc_td _ "</tr>" _
-specname_td = td_open _ kuma "</td>"
-spec2_td = td_open _ kuma "</td>"
+specname_td = td_open _ kumascript "</td>"
+spec2_td = td_open _ kumascript "</td>"
 specdesc_td = td_open _ inner_td _ "</td>"
 inner_td = ~r"(?P<content>.*?(?=</td>))"s
 
 #
 # Browser Compatibility section
 #
-compat_section = _ compat_h2 _ compat_kuma _ compat_divs p_empty*
+compat_section = _ compat_h2 _ compat_kumascript _ compat_divs p_empty*
     compat_footnotes?
 compat_h2 = "<h2 " _ attrs? _ ">" _ compat_title _ "</h2>"
 compat_title = ~r"(?P<content>Browser [cC]ompat[ai]bility)"
-compat_kuma = (compat_kuma_div / compat_kuma_p)
-compat_kuma_div = "<div>" _ kuma "</div>"
-compat_kuma_p = "<p>" _ kuma "</p>"
+compat_kumascript = (compat_kumascript_div / compat_kumascript_p)
+compat_kumascript_div = "<div>" _ kumascript "</div>"
+compat_kumascript_p = "<p>" _ kumascript "</p>"
 compat_divs = compat_div+
 compat_div = "<div" _ "id" _ equals _ compat_div_id ">" _ compat_table
     _ "</div>" _
@@ -104,7 +104,7 @@ compat_row_cell = td_open _ compat_cell _ "</td>" _
 #   or a support until we visit the table.
 #
 compat_cell = compat_cell_item*
-compat_cell_item = (kuma / cell_break / code_block / cell_p_open /
+compat_cell_item = (kumascript / cell_break / code_block / cell_p_open /
     cell_p_close / cell_version / cell_footnote_id / cell_removed / cell_other)
 cell_break = "<" _ "br" _ ("/>" / ">") _
 code_block = "<code>" _ code_text _ "</code>" _
@@ -132,17 +132,17 @@ footnote_pre_text = ~r"(?P<content>.*?(?=</pre>))"s
 #
 # Common tokens
 #
-kuma = kuma_esc_start kuma_name kuma_arglist? kuma_esc_end
-kuma_esc_start = "{{" _
-kuma_name = ~r"(?P<content>[^\(\}\s]*)\s*"s
-kuma_arglist = kuma_func_start kuma_arg kuma_arg_rest* kuma_func_end
-kuma_func_start = "(" _
-kuma_func_arg = _ "," _
-kuma_func_end = _ ")" _
-kuma_esc_end = "}}" _
-kuma_arg = (double_quoted_text / single_quoted_text / kuma_bare_arg)
-kuma_bare_arg = ~r"(?P<content>.*?(?=[,)]))"
-kuma_arg_rest = kuma_func_arg kuma_arg
+kumascript = ks_esc_start ks_name ks_arglist? ks_esc_end
+ks_esc_start = "{{" _
+ks_name = ~r"(?P<content>[^\(\}\s]*)\s*"s
+ks_arglist = ks_func_start ks_arg ks_arg_rest* ks_func_end
+ks_func_start = "(" _
+ks_func_arg = _ "," _
+ks_func_end = _ ")" _
+ks_esc_end = "}}" _
+ks_arg = (double_quoted_text / single_quoted_text / ks_bare_arg)
+ks_bare_arg = ~r"(?P<content>.*?(?=[,)]))"
+ks_arg_rest = ks_func_arg ks_arg
 
 th_elems = th_elem+
 th_elem = th_open _ (strong_text / bare_text) "</th>" _
@@ -341,15 +341,15 @@ class PageVisitor(NodeVisitor):
             'section.id': section_id})
 
     def visit_specname_td(self, node, children):
-        kuma = children[2]
-        assert isinstance(kuma, dict), type(kuma)
-        assert kuma['name'].lower() == 'specname'
-        key = self.unquote(kuma["args"][0])
+        kumascript = children[2]
+        assert isinstance(kumascript, dict), type(kumascript)
+        assert kumascript['name'].lower() == 'specname'
+        key = self.unquote(kumascript["args"][0])
         subpath = ""
         name = ""
         try:
-            subpath = self.unquote(kuma["args"][1])
-            name = self.unquote(kuma["args"][2])
+            subpath = self.unquote(kumascript["args"][1])
+            name = self.unquote(kumascript["args"][2])
         except IndexError:
             pass  # subpath and name can be empty
 
@@ -364,11 +364,11 @@ class PageVisitor(NodeVisitor):
         return (key, spec_id, subpath, name)
 
     def visit_spec2_td(self, node, children):
-        kuma = children[2]
-        assert isinstance(kuma, dict), type(kuma)
-        assert kuma['name'].lower() == 'spec2'
-        assert len(kuma["args"]) == 1
-        key = self.unquote(kuma["args"][0])
+        kumascript = children[2]
+        assert isinstance(kumascript, dict), type(kumascript)
+        assert kumascript['name'].lower() == 'spec2'
+        assert len(kumascript["args"]) == 1
+        key = self.unquote(kumascript["args"][0])
         assert isinstance(key, text_type), type(key)
         return key
 
@@ -417,12 +417,12 @@ class PageVisitor(NodeVisitor):
         self.compat = compat_divs
         self.footnotes = footnotes
 
-    def visit_compat_kuma(self, node, children):
+    def visit_compat_kumascript(self, node, children):
         assert isinstance(children, list), type(children)
-        kuma = children[0][2]
-        assert isinstance(kuma, dict), type(kuma)
-        assert kuma['type'] == 'kuma'
-        assert kuma['name'].lower() == 'compatibilitytable'
+        kumascript = children[0][2]
+        assert isinstance(kumascript, dict), type(kumascript)
+        assert kumascript['type'] == 'kumascript'
+        assert kumascript['name'].lower() == 'compatibilitytable'
 
     def visit_compat_div(self, node, children):
         compat_div_id = children[6][0]
@@ -701,7 +701,7 @@ class PageVisitor(NodeVisitor):
         footnote_id = children[3]
         text = children[5]
         assert isinstance(text, text_type), type(text)
-        fixed = self.render_footnote_kuma(text, node.children[4].start)
+        fixed = self.render_footnote_kumascript(text, node.children[4].start)
         data = {
             'type': 'p', 'content': fixed,
             'start': node.start, 'end': node.end}
@@ -745,7 +745,7 @@ class PageVisitor(NodeVisitor):
     #
     # Other visitors
     #
-    def visit_kuma(self, node, children):
+    def visit_kumascript(self, node, children):
         name = children[1]
         assert isinstance(name, text_type), type(name)
 
@@ -760,12 +760,12 @@ class PageVisitor(NodeVisitor):
         assert isinstance(args, list), type(args)
 
         return {
-            'type': 'kuma', 'name': name, 'args': args,
+            'type': 'kumascript', 'name': name, 'args': args,
             'start': node.start, 'end': node.end}
 
-    visit_kuma_name = _visit_content
+    visit_ks_name = _visit_content
 
-    def visit_kuma_arglist(self, node, children):
+    def visit_ks_arglist(self, node, children):
         arg0 = children[1]
         argrest = children[2]
         args = []
@@ -779,14 +779,14 @@ class PageVisitor(NodeVisitor):
                 args.append(arg)
         return args
 
-    def visit_kuma_arg(self, node, children):
+    def visit_ks_arg(self, node, children):
         assert isinstance(children, list)
         assert len(children) == 1
         item = children[0]
         assert isinstance(item, text_type)
         return item
 
-    visit_kuma_bare_arg = _visit_content
+    visit_ks_bare_arg = _visit_content
 
     def visit_attrs(self, node, children):
         return children  # Even if empty list
@@ -903,7 +903,7 @@ class PageVisitor(NodeVisitor):
         """Unquote strings.
 
         Used in the footnotes parser.  Might be removed if it is replaced with
-        a compat_cell tokenizer using kuma rule
+        a compat_cell tokenizer using kumascript rule
         """
         if text.startswith('"') or text.startswith("'"):
             if text[0] != text[-1]:
@@ -1043,7 +1043,7 @@ class PageVisitor(NodeVisitor):
                 name_bits.append(v)
             elif item['type'] == 'code_block':
                 name_bits.append('<code>%s</code>' % item['content'])
-            elif item['type'] == 'kuma':
+            elif item['type'] == 'kumascript':
                 kname = item['name'].lower()
                 if kname == 'experimental_inline':
                     assert 'experimental' not in feature
@@ -1068,9 +1068,10 @@ class PageVisitor(NodeVisitor):
                         args = '(' + ', '.join(item['args']) + ')'
                     else:
                         args = ''
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown kuma function %s%s' % (item['name'], args)))
+                    error = (
+                        'Unknown kumascript function %s%s'
+                        % (item['name'], args))
+                    self.errors.append((item['start'], item['end'], error))
             elif item['type'] == 'footnote_id':
                 self.errors.append((
                     item['start'], item['end'],
@@ -1122,7 +1123,7 @@ class PageVisitor(NodeVisitor):
         support = {}
         p_depth = 0
 
-        kuma_compat_versions = [
+        kumascript_compat_versions = [
             'compat' + b for b in ('android', 'chrome', 'ie', 'opera',
                                    'operamobile', 'safari')]
 
@@ -1140,7 +1141,7 @@ class PageVisitor(NodeVisitor):
                 else:
                     support['footnote_id'] = (
                         item['footnote_id'], item['start'], item['end'])
-            elif item['type'] == 'kuma':
+            elif item['type'] == 'kumascript':
                 kname = item['name'].lower()
                 # See https://developer.mozilla.org/en-US/docs/Template:<name>
                 if kname == 'compatversionunknown':
@@ -1219,16 +1220,17 @@ class PageVisitor(NodeVisitor):
                     version_found = gversion.split('.', 1)[0]
                     if version_found == '2':
                         version_found = '4'
-                elif kname in kuma_compat_versions:
+                elif kname in kumascript_compat_versions:
                     version_found = self.unquote(item['args'][0])
                 else:
                     if item['args']:
                         args = '(' + ', '.join(item['args']) + ')'
                     else:
                         args = ''
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown kuma function %s%s' % (item['name'], args)))
+                    error = (
+                        'Unknown kumascript function %s%s' %
+                        (item['name'], args))
+                    self.errors.append((item['start'], item['end'], error))
             elif item['type'] == 'p_open':
                 p_depth += 1
                 if p_depth > 1:
@@ -1329,7 +1331,7 @@ class PageVisitor(NodeVisitor):
                 bits.append(fmt % i)
             return "\n".join(bits)
 
-    re_kuma = re.compile(r'''(?x)(?s)  # Be verbose, . include newlines
+    re_kumascript = re.compile(r'''(?x)(?s)  # Be verbose, . include newlines
     {{\s*               # Kuma start, with optional whitespace
     (?P<name>\w+)       # Function name, optionally followed by...
       (\((?P<args>\s*   # Open parens and whitespace,
@@ -1338,12 +1340,11 @@ class PageVisitor(NodeVisitor):
     \s*}}               # Whitespace and Kuma close
     ''')
 
-    def render_footnote_kuma(self, text, start):
+    def render_footnote_kumascript(self, text, start):
         rendered = text
-        for match in self.re_kuma.finditer(text):
+        for match in self.re_kumascript.finditer(text):
             name = match.group('name')
             kname = name.lower()
-            kuma = match.group()
             if match.group('args'):
                 arglist = match.group('args').split(',')
             else:
@@ -1353,18 +1354,19 @@ class PageVisitor(NodeVisitor):
                 # https://developer.mozilla.org/en-US/docs/Template:cssxref
                 # The MDN version does a lookup and creates a link
                 # This version just turns it into a code block
-                kuma = "<code>%s</code>" % self.unquote(arglist[0])
+                kumascript = "<code>%s</code>" % self.unquote(arglist[0])
             else:
-                kuma = ""
+                kumascript = ""
                 if arglist:
                     args = '(' + ', '.join(arglist) + ')'
                 else:
                     args = ''
                 self.errors.append((
                     start + match.start(), start + match.end(),
-                    "Unknown footnote kuma function %s%s" % (name, args)))
+                    "Unknown footnote kumascript function %s%s" %
+                    (name, args)))
             rendered = (
-                rendered[:match.start()] + kuma + rendered[match.end():])
+                rendered[:match.start()] + kumascript + rendered[match.end():])
         return rendered
 
 

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -825,6 +825,7 @@ class PageVisitor(NodeVisitor):
     browser_name_fixes = {
         'Firefox (Gecko)': 'Firefox',
         'Firefox Mobile (Gecko)': 'Firefox Mobile',
+        'Firefox OS (Gecko)': 'Firefox OS',
         'Safari (WebKit)': 'Safari',
         'Windows Phone': 'IE Mobile',
         'IE Phone': 'IE Mobile',

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -273,7 +273,7 @@ class PageVisitor(NodeVisitor):
         attrs_list = children[2][0]
         assert isinstance(attrs_list, list), type(attrs_list)
         h2_id = None
-        expected = ('Specifications',)
+        expected = ('Specifications', 'Specification')
         for attr in attrs_list:
             assert isinstance(attr, dict), type(attr)
             if attr['ident'] == 'id':

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -114,7 +114,8 @@ cell_p_close = "</p>" _
 cell_version = ~r"(?P<version>\d+(\.\d+)*)"""
     r"""(\s+\((?P<eng_version>\d+(\.\d+)*)\))?\s*"s
 cell_removed = ~r"[Rr]emoved\s+[Ii]n\s*"s
-cell_footnote_id = ~r"\[(?P<footnote_id>\d+)\]\s*"s
+cell_footnote_id = "<sup>"? _ a_open? _ ~r"\[(?P<footnote_id>\d+|\*+)\]\s*"s _
+    "</a>"? _ "</sup>"?
 cell_other = ~r"(?P<content>[^{<[]+)\s*"s
 
 #
@@ -122,8 +123,8 @@ cell_other = ~r"(?P<content>[^{<[]+)\s*"s
 #
 compat_footnotes = footnote_item* _
 footnote_item = (footnote_p / footnote_pre)
-footnote_p = "<p>" _ footnote_id? _ footnote_p_text "</p>" _
-footnote_id = "[" ~r"(?P<content>\d+)" "]"
+footnote_p = "<p>" a_both? _ footnote_id? _ footnote_p_text "</p>" _
+footnote_id = "[" ~r"(?P<content>\d+|\*+)" "]"
 footnote_p_text = ~r"(?P<content>.*?(?=</p>))"s
 footnote_pre = "<pre" attrs? ">" footnote_pre_text "</pre>" _
 footnote_pre_text = ~r"(?P<content>.*?(?=</pre>))"s
@@ -148,6 +149,8 @@ th_elem = th_open _ (strong_text / bare_text) "</th>" _
 tr_open = "<tr" _ opt_attrs ">"
 th_open = "<th" _ opt_attrs ">"
 td_open = "<td" _ opt_attrs ">"
+a_open = "<a" _  opt_attrs ">"
+a_both = _ a_open _ "</a>" _
 
 p_empty = _ "<p>" _ "&nbsp;"* _ "</p>" _
 
@@ -611,9 +614,15 @@ class PageVisitor(NodeVisitor):
             'start': node.start, 'end': node.end}
 
     def visit_cell_footnote_id(self, node, children):
+        item = children[4]
+        raw_id = item.match.group('footnote_id')
+        if raw_id.isnumeric():
+            footnote_id = raw_id
+        else:
+            footnote_id = str(len(raw_id))
         return {
             'type': 'footnote_id',
-            'footnote_id': node.match.group('footnote_id'),
+            'footnote_id': footnote_id,
             'start': node.start, 'end': node.end}
 
     def visit_cell_removed(self, node, children):
@@ -675,8 +684,8 @@ class PageVisitor(NodeVisitor):
         return item
 
     def visit_footnote_p(self, node, children):
-        footnote_id = children[2]
-        text = children[4]
+        footnote_id = children[3]
+        text = children[5]
         assert isinstance(text, text_type), type(text)
         fixed = self.render_footnote_kuma(text, node.children[4].start)
         data = {
@@ -687,7 +696,11 @@ class PageVisitor(NodeVisitor):
         return data
 
     def visit_footnote_id(self, node, children):
-        footnote_id = children[1].match.group('content')
+        raw_id = children[1].match.group('content')
+        if raw_id.isnumeric():
+            footnote_id = raw_id
+        else:
+            footnote_id = str(len(raw_id))
         return footnote_id
 
     visit_footnote_p_text = _visit_content

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1168,6 +1168,52 @@ class PageVisitor(NodeVisitor):
                             self.errors.append((
                                 item['start'], item['end'],
                                 'Unknown Gecko version "%s"' % gversion))
+                elif kname == 'compatgeckofxos':
+                    gversion = self.unquote(item['args'][0])
+                    try:
+                        oversion = self.unquote(item['args'][1])
+                    except IndexError:
+                        oversion = ''
+                    try:
+                        nversion = float(gversion)
+                    except ValueError:
+                        nversion = -1
+                    if (nversion >= 0 and nversion < 19 and
+                       oversion in ('', '1.0')):
+                        version_found = '1.0'
+                    elif (nversion >= 0 and nversion < 21 and
+                          oversion == '1.0.1'):
+                        version_found = '1.0.1'
+                    elif (nversion >= 0 and nversion < 24 and
+                          oversion in ('1.1', '1.1.0', '1.1.1')):
+                        version_found = '1.1'
+                    elif (nversion >= 19 and nversion < 27 and
+                          oversion in ('', '1.2')):
+                        version_found = '1.2'
+                    elif (nversion >= 27 and nversion < 29 and
+                          oversion in ('', '1.3')):
+                        version_found = '1.3'
+                    elif (nversion >= 29 and nversion < 31 and
+                          oversion in ('', '1.4')):
+                        version_found = '1.4'
+                    elif (nversion >= 31 and nversion < 33 and
+                          oversion in ('', '2.0')):
+                        version_found = '2.0'
+                    elif (nversion >= 33 and nversion < 35 and
+                          oversion in ('', '2.1')):
+                        version_found = '2.1'
+                    elif (nversion >= 35 and nversion < 38 and
+                          oversion in ('', '2.2')):
+                        version_found = '2.2'
+                    elif nversion < 0 or nversion >= 38:
+                        self.errors.append((
+                            item['start'], item['end'],
+                            'Unknown Gecko version "%s"' % gversion))
+                    else:
+                        self.errors.append((
+                            item['start'], item['end'],
+                            ('Override "%s" is invalid for '
+                             'Gecko version "%s"' % (oversion, gversion))))
                 elif kname == 'compatgeckomobile':
                     gversion = self.unquote(item['args'][0])
                     version_found = gversion.split('.', 1)[0]

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -63,16 +63,14 @@ spec_head = spec_thead_headers / spec_tbody_headers
 spec_thead_headers = "<thead>" _ spec_headers "</thead>" _ spec_tbody _
 spec_tbody_headers = spec_tbody _ spec_headers
 spec_headers =  "<tr>" _ th_elems _ "</tr>" _
-th_elems = th_elem+
-th_elem = "<th scope=\"col\">" _ (!"</th>" bare_text) _ "</th>" _
 spec_tbody = "<tbody>"
 
 spec_body = spec_rows "</tbody>"
 spec_rows = spec_row+
-spec_row = "<tr>" _ specname_td _ spec2_td _ specdesc_td _ "</tr>" _
-specname_td = "<td>" _ kuma "</td>"
-spec2_td = "<td>" _ kuma "</td>"
-specdesc_td = "<td>" _ inner_td _ "</td>"
+spec_row = tr_open _ specname_td _ spec2_td _ specdesc_td _ "</tr>" _
+specname_td = td_open _ kuma "</td>"
+spec2_td = td_open _ kuma "</td>"
+specdesc_td = td_open _ inner_td _ "</td>"
 inner_td = ~r"(?P<content>.*?(?=</td>))"s
 
 #
@@ -146,6 +144,8 @@ kuma_arg = (double_quoted_text / single_quoted_text / kuma_bare_arg)
 kuma_bare_arg = ~r"(?P<content>.*?(?=[,)]))"
 kuma_arg_rest = kuma_func_arg kuma_arg
 
+th_elems = th_elem+
+th_elem = th_open _ bare_text "</th>" _
 tr_open = "<tr" _ opt_attrs ">"
 th_open = "<th" _ opt_attrs ">"
 td_open = "<td" _ opt_attrs ">"
@@ -815,6 +815,14 @@ class PageVisitor(NodeVisitor):
                     attr['start'], attr['end'],
                     "Unexpected attribute <%s %s=\"%s\">" % (
                         node_dict['type'], ident, attr['value'])))
+
+    def visit_th_elem(self, node, children):
+        th_open = children[0]
+        text = children[2]
+        assert isinstance(th_open, dict), type(th_open)
+        assert isinstance(text, text_type), type(text)
+        th_open['text'] = self.cleanup_whitespace(text)
+        return th_open
 
     def visit_td_open(self, node, children):
         return self._visit_open(node, children, 'td')

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -478,7 +478,12 @@ class PageVisitor(NodeVisitor):
         for row, compat_row in enumerate(compat_rows):
             for cell in compat_row['cells']:
                 td = cell[0]
-                col = table[row].index(None)
+                try:
+                    col = table[row].index(None)
+                except ValueError:
+                    error = "Extra cell in table"
+                    self.errors.append((td['start'], cell[-1]['end'], error))
+                    continue
                 rowspan = int(td.get('rowspan', 1))
                 colspan = int(td.get('colspan', 1))
                 if col == 0:

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -251,15 +251,29 @@ class PageVisitor(NodeVisitor):
                 try:
                     page_grammar[section].parse(text)
                 except ParseError as pe:
-                    rule = pe.expr
-                    description = (
-                        'Section <h2>%s</h2> was not parsed, because rule'
-                        ' "%s" failed to match.  Definition:'
-                        % (title, rule.name))
-                    error = (
-                        pe.pos + start, end_of_line(pe.text, pe.pos) + start,
-                        description, rule.as_rule())
-                    self.errors.append(error)
+                    if self.errors:
+                        rule = pe.expr
+                        description = (
+                            'Section <h2>%s</h2> was not parsed.'
+                            ' The parser failed on rule "%s", but the real'
+                            ' cause is probably earlier issues. Definition:'
+                            % (title, rule.name))
+                        self.errors.append((
+                            pe.pos + start,
+                            end_of_line(pe.text, pe.pos) + start,
+                            description, rule.as_rule()))
+                    else:
+                        rule = pe.expr
+                        description = (
+                            'Section <h2>%s</h2> was not parsed. The parser'
+                            ' failed on rule "%s", but the real cause may be'
+                            ' unexpected content after this position.'
+                            ' Definition:' % (title, rule.name))
+                        self.errors.append((
+                            pe.pos + start,
+                            end_of_line(pe.text, pe.pos) + start,
+                            description, rule.as_rule()))
+
                 else:  # pragma: nocover
                     error = (
                         start, end_of_line(text, 0) + start,

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -427,19 +427,12 @@ class TestPageVisitor(ScrapeTestCase):
             '<h2 id="Specifications" extra="crazy">Specifications</h2>', [])
 
     def test_spec_h2_specification_id(self):
-        self.assert_spec_h2(
-            '<h2 id="Specification">Specifications</h2>',
-            [(4, 22,
-              ('In Specifications section, expected <h2 id="Specifications">,'
-               ' actual id="Specification"'))])
+        self.assert_spec_h2('<h2 id="Specification">Specifications</h2>', [])
 
     def test_spec_h2_specification_name(self):
         self.assert_spec_h2(
             '<h2 id="Specifications" name="Specification">Specifications</h2>',
-            [(24, 44,
-              ('In Specifications section, expected <h2'
-               ' name="Specifications"> or no name attribute, actual'
-               ' name="Specification"'))])
+            [])
 
     def test_spec_h2_browser_compat(self):
         # Common bug from copying from Browser Compatibility section

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1171,6 +1171,51 @@ class TestPageVisitor(ScrapeTestCase):
             '{{CompatGeckoDesktop("1.1")}}',
             expected_errors=[(4, 33, 'Unknown Gecko version "1.1"')])
 
+    def test_compat_row_cell_support_compatgeckofxos_7(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("7")}}',
+            [{'version': '1.0'}], [{'support': 'yes'}])
+
+    def test_compat_row_cell_support_compatgeckofxos_7_version_1_0_1(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("7","1.0.1")}}',
+            [{'version': '1.0.1'}], [{'support': 'yes'}])
+
+    def test_compat_row_cell_support_compatgeckofxos_7_version_1_1(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("7","1.1")}}',
+            [{'version': '1.1'}], [{'support': 'yes'}])
+
+    def test_compat_row_cell_support_compatgeckofxos_range(self):
+        versions = {'10': '1.0',
+                    '24': '1.2',
+                    '28': '1.3',
+                    '29': '1.4',
+                    '32': '2.0',
+                    '34': '2.1',
+                    '35': '2.2'
+                    }
+        for gversion, oversion in versions.items():
+            self.assert_compat_row_cell_support(
+                '{{CompatGeckoFxOS("%s")}}' % gversion,
+                [{'version': oversion}], [{'support': 'yes'}])
+
+    def test_compat_row_cell_support_compatgeckofxos_bad_gecko(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("9999999")}}',
+            expected_errors=[(4, 34, 'Unknown Gecko version "9999999"')])
+
+    def test_compat_row_cell_support_compatgeckofxos_bad_text(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("Yep")}}',
+            expected_errors=[(4, 30, 'Unknown Gecko version "Yep"')])
+
+    def test_compat_row_cell_support_compatgeckofxos_bad_version(self):
+        self.assert_compat_row_cell_support(
+            '{{CompatGeckoFxOS("18","5.0")}}',
+            expected_errors=[(4, 35, ('Override "5.0" is invalid for '
+                                      'Gecko version "18"'))])
+
     def test_compat_row_cell_support_compatgeckomobile_1(self):
         self.assert_compat_row_cell_support(
             '{{CompatGeckoMobile("1")}}',

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -14,6 +14,18 @@ from webplatformcompat.tests.base import TestCase
 
 
 class TestGrammar(TestCase):
+    def test_other_h2_plain(self):
+        text = "<h2 id=\"Summary\">Summary</h2>"
+        parsed = page_grammar['other_h2'].parse(text)
+        capture = parsed.children[6]
+        self.assertEqual("Summary", capture.text)
+
+    def test_other_h2_code(self):
+        text = "<h2 id=\"Summary\"><code>Summary</code></h2>"
+        parsed = page_grammar['other_h2'].parse(text)
+        capture = parsed.children[6]
+        self.assertEqual("<code>Summary</code>", capture.text)
+
     def test_specdesc_td_empty(self):
         text = '<td></td>'
         parsed = page_grammar['specdesc_td'].parse(text)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1977,7 +1977,7 @@ class TestScrape(ScrapeTestCase):
         }
         self.assertScrape(page, expected)
 
-    def test_unable_to_parse_compat(self):
+    def test_unable_to_parse_compat_first(self):
         good = '<td>{{CompatGeckoDesktop("1")}}</td>'
         bad = '<td><kuma>CompatGeckoDesktop("1")</kuma></td>'
         self.assertTrue(good in self.simple_compat_section)
@@ -1990,9 +1990,47 @@ class TestScrape(ScrapeTestCase):
             'issues': [],
             'errors': [
                 (377, 418,
-                 'Section <h2>Browser compatibility</h2> was not parsed,'
-                 ' because rule "compat_cell_item" failed to match.'
-                 '  Definition:',
+                 'Section <h2>Browser compatibility</h2> was not parsed.'
+                 ' The parser failed on rule "compat_cell_item", but the'
+                 ' real cause may be unexpected content after this'
+                 ' position. Definition:',
+                 'compat_cell_item = kuma / cell_break / code_block /'
+                 ' cell_p_open / cell_p_close / cell_version /'
+                 ' cell_footnote_id / cell_removed / cell_other')
+            ]
+        }
+        self.assertScrape(page, expected)
+
+    def test_unable_to_parse_compat_second(self):
+        good_spec = "{{SpecName('CSS3 Backgrounds',"
+        bad_spec = "{{SpecName('CRAZY',"
+        self.assertTrue(good_spec in self.simple_spec_section)
+        page = self.simple_spec_section.replace(good_spec, bad_spec)
+        good_compat = '<td>{{CompatGeckoDesktop("1")}}</td>'
+        bad_compat = '<td><kuma>CompatGeckoDesktop("1")</kuma></td>'
+        self.assertTrue(good_compat in self.simple_compat_section)
+        page += self.simple_compat_section.replace(good_compat, bad_compat)
+        expected = {
+            'locale': 'en',
+            'specs': [{
+                'section.id': None,
+                'section.name': u'background-size',
+                'section.note': u'',
+                'section.subpath': u'#the-background-size',
+                'specification.id': None,
+                'specification.mdn_key': u'CRAZY'}],
+            'compat': [],
+            'footnotes': None,
+            'issues': [],
+            'errors': [
+                (251, 324, 'Unknown Specification "CRAZY"'),
+                (243, 389,
+                 'SpecName(CSS3 Backgrounds, ...) does not match'
+                 ' Spec2(CRAZY)'),
+                (784, 825,
+                 'Section <h2>Browser compatibility</h2> was not parsed.'
+                 ' The parser failed on rule "compat_cell_item", but the'
+                 ' real cause is probably earlier issues. Definition:',
                  'compat_cell_item = kuma / cell_break / code_block /'
                  ' cell_p_open / cell_p_close / cell_version /'
                  ' cell_footnote_id / cell_removed / cell_other')

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -900,21 +900,21 @@ class TestPageVisitor(ScrapeTestCase):
         }
         self.assert_compat_row_cell_feature(text, expected_feature)
 
-    def test_compat_row_cell_feature_unknown_kuma(self):
+    def test_compat_row_cell_feature_unknown_kumascript(self):
         text = 'feature foo {{bar}}'
         feature = {
             'id': '_feature foo', 'name': 'feature foo',
             'slug': 'web-css-background-size_feature_foo',
         }
-        expected_errors = [(16, 23, 'Unknown kuma function bar')]
+        expected_errors = [(16, 23, 'Unknown kumascript function bar')]
         self.assert_compat_row_cell_feature(
             text, feature, expected_errors=expected_errors)
 
-    def test_compat_row_cell_feature_unknown_kuma_with_args(self):
+    def test_compat_row_cell_feature_unknown_kumascript_with_args(self):
         text = 'foo {{bar("baz")}}'
         feature = {
             'id': '_foo', 'name': 'foo', 'slug': 'web-css-background-size_foo'}
-        expected_errors = [(8, 22, 'Unknown kuma function bar(baz)')]
+        expected_errors = [(8, 22, 'Unknown kumascript function bar(baz)')]
         self.assert_compat_row_cell_feature(
             text, feature, expected_errors=expected_errors)
 
@@ -1236,16 +1236,17 @@ class TestPageVisitor(ScrapeTestCase):
             '{{CompatAndroid("3.0")}}',
             [{'version': '3.0'}], [{'support': 'yes'}])
 
-    def test_compat_row_cell_support_unknown_kuma(self):
+    def test_compat_row_cell_support_unknown_kumascript(self):
         self.assert_compat_row_cell_support(
             '{{UnknownKuma}}',
-            expected_errors=[(4, 19, "Unknown kuma function UnknownKuma")])
+            expected_errors=[
+                (4, 19, "Unknown kumascript function UnknownKuma")])
 
-    def test_compat_row_cell_support_unknown_kuma_args(self):
+    def test_compat_row_cell_support_unknown_kumascript_args(self):
         self.assert_compat_row_cell_support(
             '{{UnknownKuma("foo")}}',
             expected_errors=[
-                (4, 26, 'Unknown kuma function UnknownKuma(foo)')])
+                (4, 26, 'Unknown kumascript function UnknownKuma(foo)')])
 
     def test_compat_row_cell_support_nested_p(self):
         self.assert_compat_row_cell_support(
@@ -1370,7 +1371,7 @@ class TestPageVisitor(ScrapeTestCase):
         }
         self.assertEqual(expected, self.visitor.visit(parsed))
 
-    def test_compat_footnotes_kuma_cssxref(self):
+    def test_compat_footnotes_kumascript_cssxref(self):
         text = '<p>[1] Use {{cssxref("-moz-border-image")}}</p>'
         parsed = page_grammar['compat_footnotes'].parse(text)
         expected = {
@@ -1378,23 +1379,24 @@ class TestPageVisitor(ScrapeTestCase):
         }
         self.assertEqual(expected, self.visitor.visit(parsed))
 
-    def test_compat_footnotes_unknown_kumascript(self):
+    def test_compat_footnotes_unknown_kumascriptscript(self):
         text = "<p>[1] Footnote {{UnknownKuma}} but the beat continues.</p>"
         parsed = page_grammar['compat_footnotes'].parse(text)
         expected = {
             '1': ('Footnote  but the beat continues.', 0, 59)}
         self.assertEqual(expected, self.visitor.visit(parsed))
         expected_errors = [
-            (15, 30, "Unknown footnote kuma function UnknownKuma")]
+            (15, 30, "Unknown footnote kumascript function UnknownKuma")]
         self.assertEqual(expected_errors, self.visitor.errors)
 
-    def test_compat_footnotes_unknown_kumascript_with_args(self):
+    def test_compat_footnotes_unknown_kumascriptscript_with_args(self):
         text = '<p>[1] Footnote {{UnknownKuma("arg")}}</p>'
         parsed = page_grammar['compat_footnotes'].parse(text)
         expected = {'1': ('Footnote ', 0, 42)}
         self.assertEqual(expected, self.visitor.visit(parsed))
         expected_errors = [
-            (15, 37, 'Unknown footnote kuma function UnknownKuma("arg")')]
+            (15, 37,
+             'Unknown footnote kumascript function UnknownKuma("arg")')]
         self.assertEqual(expected_errors, self.visitor.errors)
 
     def test_compat_footnotes_pre_section(self):
@@ -1433,34 +1435,34 @@ class TestPageVisitor(ScrapeTestCase):
         errors = [(0, 18, 'No ID in footnote.')]
         self.assertEqual(errors, self.visitor.errors)
 
-    def assert_kuma(self, text, name, args, errors=None):
-        parsed = page_grammar['kuma'].parse(text)
+    def assert_kumascript(self, text, name, args, errors=None):
+        parsed = page_grammar['kumascript'].parse(text)
         expected = {
-            'type': 'kuma', 'name': name, 'args': args,
+            'type': 'kumascript', 'name': name, 'args': args,
             'start': 0, 'end': len(text)}
         self.assertEqual(expected, self.visitor.visit(parsed))
         self.assertEqual(errors or [], self.visitor.errors)
 
-    def test_kuma_no_parens(self):
-        self.assert_kuma('{{CompatNo}}', 'CompatNo', [])
+    def test_kumascript_no_parens(self):
+        self.assert_kumascript('{{CompatNo}}', 'CompatNo', [])
 
-    def test_kuma_no_parens_and_spaces(self):
-        self.assert_kuma('{{ CompatNo }}', 'CompatNo', [])
+    def test_kumascript_no_parens_and_spaces(self):
+        self.assert_kumascript('{{ CompatNo }}', 'CompatNo', [])
 
-    def test_kuma_empty_parens(self):
-        self.assert_kuma('{{CompatNo()}}', 'CompatNo', [])
+    def test_kumascript_empty_parens(self):
+        self.assert_kumascript('{{CompatNo()}}', 'CompatNo', [])
 
-    def test_kuma_one_arg(self):
-        self.assert_kuma(
+    def test_kumascript_one_arg(self):
+        self.assert_kumascript(
             '{{cssxref("-moz-border-image")}}', 'cssxref',
             ['-moz-border-image'])
 
-    def test_kuma_one_arg_no_quotes(self):
-        self.assert_kuma(
+    def test_kumascript_one_arg_no_quotes(self):
+        self.assert_kumascript(
             '{{CompatGeckoDesktop(27)}}', 'CompatGeckoDesktop', ['27'])
 
-    def test_kuma_three_args(self):
-        self.assert_kuma(
+    def test_kumascript_three_args(self):
+        self.assert_kumascript(
             ("{{SpecName('CSS3 Backgrounds', '#the-background-size',"
              " 'background-size')}}"),
             "SpecName",
@@ -2024,7 +2026,7 @@ class TestScrape(ScrapeTestCase):
 
     def test_unable_to_parse_compat_first(self):
         good = '<td>{{CompatGeckoDesktop("1")}}</td>'
-        bad = '<td><kuma>CompatGeckoDesktop("1")</kuma></td>'
+        bad = '<td><ks>CompatGeckoDesktop("1")</ks></td>'
         self.assertTrue(good in self.simple_compat_section)
         page = self.simple_compat_section.replace(good, bad)
         expected = {
@@ -2034,12 +2036,12 @@ class TestScrape(ScrapeTestCase):
             'footnotes': None,
             'issues': [],
             'errors': [
-                (377, 418,
+                (377, 414,
                  'Section <h2>Browser compatibility</h2> was not parsed.'
                  ' The parser failed on rule "compat_cell_item", but the'
                  ' real cause may be unexpected content after this'
                  ' position. Definition:',
-                 'compat_cell_item = kuma / cell_break / code_block /'
+                 'compat_cell_item = kumascript / cell_break / code_block /'
                  ' cell_p_open / cell_p_close / cell_version /'
                  ' cell_footnote_id / cell_removed / cell_other')
             ]
@@ -2052,7 +2054,7 @@ class TestScrape(ScrapeTestCase):
         self.assertTrue(good_spec in self.simple_spec_section)
         page = self.simple_spec_section.replace(good_spec, bad_spec)
         good_compat = '<td>{{CompatGeckoDesktop("1")}}</td>'
-        bad_compat = '<td><kuma>CompatGeckoDesktop("1")</kuma></td>'
+        bad_compat = '<td><ks>CompatGeckoDesktop("1")</ks></td>'
         self.assertTrue(good_compat in self.simple_compat_section)
         page += self.simple_compat_section.replace(good_compat, bad_compat)
         expected = {
@@ -2072,11 +2074,11 @@ class TestScrape(ScrapeTestCase):
                 (243, 389,
                  'SpecName(CSS3 Backgrounds, ...) does not match'
                  ' Spec2(CRAZY)'),
-                (784, 825,
+                (784, 821,
                  'Section <h2>Browser compatibility</h2> was not parsed.'
                  ' The parser failed on rule "compat_cell_item", but the'
                  ' real cause is probably earlier issues. Definition:',
-                 'compat_cell_item = kuma / cell_break / code_block /'
+                 'compat_cell_item = kumascript / cell_break / code_block /'
                  ' cell_p_open / cell_p_close / cell_version /'
                  ' cell_footnote_id / cell_removed / cell_other')
             ]


### PR DESCRIPTION
This branch includes various importer fixes contributed by @trevorhobson.  It does not close [bug 1132269](https://bugzilla.mozilla.org/show_bug.cgi?id=1132269), but closes several dependent bugs:

* [bug 1132694](https://bugzilla.mozilla.org/show_bug.cgi?id=1132694) - Allowing just bare_text in h2 is too restrictive
* [bug 1134426](https://bugzilla.mozilla.org/show_bug.cgi?id=1134426) - Browser Compatibility scrape fails with tags in header
* [bug 1134474](https://bugzilla.mozilla.org/show_bug.cgi?id=1134474) - Tags in feature heading cell cause issue (*not auto-closed w/ commit*)
* [bug 1134586](https://bugzilla.mozilla.org/show_bug.cgi?id=1134586) - Firefox OS (Gecko) be fixed to match Firefox OS
* [bug 1134587](https://bugzilla.mozilla.org/show_bug.cgi?id=1134587) - Add CompatGeckoFxOS to scraper
* [bug 1134624](https://bugzilla.mozilla.org/show_bug.cgi?id=1134624) - Remove requirement for Specifications th to have scope="col"
* [bug 1135000](https://bugzilla.mozilla.org/show_bug.cgi?id=1135000) - See also section is being incorrectly included in Browser compatibility section
* [bug 1135060](https://bugzilla.mozilla.org/show_bug.cgi?id=1135060) - Handle links on footnote ids
* [bug 1138458](https://bugzilla.mozilla.org/show_bug.cgi?id=1138458) - Use "kumascript" rather than "kuma" in code
* [bug 1139433](https://bugzilla.mozilla.org/show_bug.cgi?id=1139433) - Allow id="Specification" for Specifications `<h2>`
* [bug 1140009](https://bugzilla.mozilla.org/show_bug.cgi?id=1140009) - Extra cell should be error, not break parser


Parser results have been added to the [spreadsheet](https://docs.google.com/spreadsheets/d/1UcSYEoTy_H-T1KIQV-gH50pHzHXqpkm63Kl4XqrILUM/edit#gid=748655155)