### PR TITLE
Fix bug 1063152 - add change control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,4 +16,5 @@ omit =
     tools/sample_mdn.py
     tools/sync_from_api.py
     tools/upload_data.py
+    mdn/migrations/*.py
     webplatformcompat/migrations/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+env:
+    global:
+        - DATABASE_URL="postgres://postgres@localhost:5432/travis_ci_test"
+    matrix:
+        - TOXENV=py27
+        - TOXENV=py34
+        - TOXENV=docs
+        - TOXENV=flake8
+        - TOXENV=coverage
 
-python:
-  - "3.4"
-  - "2.7"
-
-install: pip install -r requirements.txt coveralls
+install: pip install tox
 before_script: psql -c 'create database travis_ci_test;' -U postgres
-script: DATABASE_URL="postgres://postgres@localhost:5432/travis_ci_test" python manage.py test --with-coverage --cover-package=webplatformcompat
-after_success: coveralls
+script: tox

--- a/bcauth/tests.py
+++ b/bcauth/tests.py
@@ -17,7 +17,7 @@ class TestViews(TestCase):
         self.assertEqual(response['Location'], self.reverse('account_login'))
 
     def test_account_logged_in(self):
-        self.login_superuser()
+        self.login_user()
         response = self.client.get(reverse('account_base'))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], self.reverse('account_profile'))
@@ -31,7 +31,8 @@ class TestViews(TestCase):
             self.reverse('account_login') + '?next=' + url)
 
     def test_profile_logged_in(self):
-        self.login_superuser()
+        user = self.login_user()
+        user.emailaddress_set.create(email=user.email)
         response = self.client.get(reverse('account_profile'))
         self.assertEqual(response.status_code, 200)
 

--- a/docs/draft/change-control.rst
+++ b/docs/draft/change-control.rst
@@ -19,11 +19,10 @@ The representation includes:
     - **agreement** - The version of the contribution agreement the
       user has accepted.  "0" for not agreed, "1" for first version, etc.
     - **permissions** - A list of permissions.  Permissions include
-      ``"change-support"`` (add or change a support_),
       ``"change-resource"`` (add or change any resource except users_ or
       history resources),
-      ``"change-user"`` (change a user_ resource), and
       ``"delete-resource"`` (delete any resource)
+      ``"import-mdn"`` (setup import of an MDN page)
 * **links**
     - **changesets** *(many)* - Associated changesets_, in ID order, changes
       are ignored.
@@ -51,7 +50,7 @@ A sample response is:
             "username": "askDNA@tdv.com",
             "created": "1405000551.750000",
             "agreement": "1",
-            "permissions": ["change-support"],
+            "permissions": ["change-resource"],
             "links": {
                 "changesets": ["73"]
             }
@@ -138,9 +137,9 @@ A sample response is:
             "id": "73",
             "created": "1405353048.910000",
             "modified": "1405353048.910000",
+            "closed": true,
             "target_resource_type": "features",
             "target_resource_id": "35",
-            "closed": true,
             "links": {
                 "user": "42",
                 "historical_browsers": [],

--- a/docs/draft/services.rst
+++ b/docs/draft/services.rst
@@ -9,30 +9,33 @@ Authentication
 
 Several endpoint handle user authentication.
 
-https://browsersupports.org/auth is an HTML page that shows the user's
-current authentication status, and includes a button for starting a Persona_
-login.
+https://browsersupports.org/accounts/profile/ is an HTML page that summarizes the
+users' account, which includes:
 
-One endpoint implements Persona logins.  See the `Persona Quick Setup`_ for
-details:
+* The username, which can't be changed.
+* Changing or setting the password, which is optional if a linked account is
+  used.
+* Viewing, adding, and removing linked accounts, which are optional if a
+  password is set.  The support linked account type is `Firefox Accounts`_.
+* Viewing, adding, and removing emails.  Emails can be verified (a link is
+  clicked or a trusted linked accout says it is verified), and one is the
+  primary email used for communication.
 
-* ``/auth/persona/login`` - Exchanges a Persona assertion for a login cookie.
-  If the email is not on the system, then a new user_ resource is created.  If
-  the user has not accepted the latest version of the contribution agreement,
-  then they are redirected to a page to accept it.  Otherwise, they are
-  redirected to /auth.
+Additional endpoints for authentication:
 
-Four endpoints are used for OAuth2_ used to exchange Persona credentials for
-credentials usable from a server:
+* ``/accounts/`` - Redirect to login or profile, depending on login state
+* ``/accounts/signup/`` - Create a new account, using username and password
+* ``/accounts/login/`` - Login to an existing account, using username and
+  password or selecting a linked account
+* ``/accounts/logout/`` - Logout from site
+* ``/accounts/password/change/`` - Change an existing password
+* ``/accounts/password/set/`` - Set the password for an account using only a
+  linked account
+* ``/accounts/email/`` - Manage associated email addresses
+* ``/accounts/password/reset/`` - Start a password reset via email
+* ``/accounts/social/connections/`` - Manage social accounts
+* ``/accounts/fxa/login/`` - Start a `Firefox Accounts`_ login
 
-* ``/auth/oauth2/authorize``
-* ``/auth/oauth2/authorize/confirm``
-* ``/auth/oauth2/redirect``
-* ``/auth/oauth2/access_token``
-
-A final endpoint is used to delete the credential and log out the user:
-
-* ``/auth/logout``
 
 Browser Identification
 ----------------------
@@ -52,9 +55,7 @@ further speced as part of the UX around user contributions.
 
 .. _user: change-control.html#users
 
-.. _OAuth2: http://tools.ietf.org/html/rfc6749
-.. _Persona: http://www.mozilla.org/en-US/persona/
-.. _`Persona Quick Setup`: https://developer.mozilla.org/en-US/Persona/Quick_Setup
+.. _`Firefox Accounts`: https://accounts.firefox.com/signup
 .. _WhichBrowser: https://github.com/NielsLeenheer/WhichBrowser
 .. _ua-parser: https://github.com/tobie/ua-parser
 .. _`reference parser`: https://webplatform.github.io/browser-compat-model/#reference-user-agent-parser

--- a/mdn/migrations/0002_data_add_group.py
+++ b/mdn/migrations/0002_data_add_group.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from itertools import chain
+
+from django.db import migrations
+
+group_perms = {
+    'import-mdn': [
+        'add_featurepage',
+        'change_featurepage',
+        'add_feature',
+        'change_feature',
+    ],
+}
+
+
+def add_groups(apps, schema_editor, with_create_permissions=True):
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+    try:
+        perms = dict(
+            [(codename, Permission.objects.get(codename=codename))
+             for codename in set(chain(*group_perms.values()))])
+    except Permission.DoesNotExist:
+        if with_create_permissions:
+            # create_permissions runs in the post_migrate signal, at the end of
+            # all migrations. If migrating a fresh database (such as during
+            # tests), then manually run create_permissions.
+            from django.contrib.auth.management import create_permissions
+            assert not getattr(apps, 'models_module', None)
+            apps.models_module = True
+            create_permissions(apps, verbosity=0)
+            apps.models_module = None
+            return add_groups(
+                apps, schema_editor, with_create_permissions=False)
+        else:
+            raise
+
+    for group_name in sorted(group_perms.keys()):
+        group = Group.objects.create(name=group_name)
+        perm_list = [
+            perms[codename] for codename in group_perms[group_name]]
+        group.permissions.add(*perm_list)
+
+
+def drop_groups(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name__in=list(group_perms.keys())).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_groups, drop_groups),
+    ]

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -35,6 +35,7 @@ class TestFeaturePageListView(TestCase):
 
 class TestFeaturePageCreateView(TestCase):
     def setUp(self):
+        self.login_user(groups=['import-mdn', 'change-resource'])
         self.url = reverse('feature_page_create')
         self.feature = self.create(Feature)
 
@@ -108,7 +109,7 @@ class TestFeaturePageSearch(TestCase):
         self.assertRedirects(response, next_url)
 
     def test_not_found_with_perms(self):
-        self.login_superuser()
+        self.login_user(groups=['import-mdn'])
         response = self.client.get(self.url, {'url': self.mdn_url})
         next_url = reverse('feature_page_create') + '?url=' + self.mdn_url
         self.assertRedirects(response, next_url)

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -14,7 +14,7 @@ from .tasks import start_crawl, parse_page
 
 
 def can_create(user):
-    return user.is_authenticated and user.is_staff
+    return user.has_perm('mdn.add_featurepage')
 
 
 def can_refresh(user):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,20 +2,24 @@
 
 # Documentation
 Pygments==2.0.2
-Sphinx==1.3
+sphinx-rtd-theme==0.1.7
+alabaster==0.7.3
+Babel==1.3
+snowballstemmer==1.2.0
+Sphinx==1.3.1
 docutils==0.12
 
 # Multi-environment testing
 py==1.4.26
 virtualenv==12.0.7
-tox==1.9.0
+tox==1.9.2
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3
-pep8==1.6.2
+pep8==1.5.7  # rq.filter: <1.6,>=1.5.7
 pyflakes==0.8.1
 flake8==2.4.0
-pep257==0.4.1
+pep257==0.5.0
 flake8-docstrings==0.2.1.post1
 
 # MANIFEST.in checker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for production / heroku
 
 # Django
-Django==1.7.6
+Django==1.7.7
 
 # Better templates
 MarkupSafe==0.23
@@ -16,25 +16,20 @@ django-filter==0.9.2
 
 # Django extensions
 six==1.9.0
-django-extensions==1.5.1
+django-extensions==1.5.2
 
 # JSON API interfaces for Django REST Framework
-https://github.com/jwhitlock/drf-json-api/archive/v0.1d.zip
+git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api
 
 # History of changes to models
-# django-simple-history==1.5.0 has deprecation warnings w/ Django 1.7
-# PR #141 - Fix issue with Meta.order_with_respect_to
-# Use my django-simple-history w/ PR #141 on 2014-11-16
-git+git://github.com/jwhitlock/django-simple-history.git@order_wrt_included#egg=django-simple-history
+django-simple-history==1.5.4
 
 # Configure database from env
 dj-database-url==0.3.0
 
 # Better test runner (included in settings)
 nose==1.3.4
-# django-nose==1.2 has deprecation warnings w/ Django 1.7
-# Use django-nose head on 2014-11-15
-git+git://github.com/django-nose/django-nose.git@b81f8471e#egg=django-nose
+django-nose==1.3
 
 # Test Mocking, included in Python 3.3
 mock==1.0.1
@@ -50,15 +45,12 @@ static3==0.5.1
 dj-static==0.0.6
 
 # Timezone info
-pytz==2014.10
+pytz==2015.2
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
-# pylibmc==1.3.0 does not support Python 3.3 or 3.4
-# Use pylibmc head on 2014-11-15
-git+git://github.com/lericson/pylibmc.git@c6da0ed9c#egg=pylibmc
-# django-pylibmc==0.5.0 has Python 3.x and Django 1.6/1.7 problems
-# Use my py3 branch on 2014-11-15
-git+git://github.com/jwhitlock/django-pylibmc@a6020ce#egg=django-pylibmc
+pylibmc==1.4.1
+# Use my branch, PR #30
+git+git://github.com/jwhitlock/django-pylibmc@pylibmc_14#egg=django-pylibmc
 django-pylibmc-sasl==0.2.4
 
 # Celery - async task management
@@ -78,7 +70,8 @@ django-sortedm2m==0.9.4
 drf-cached-instances==0.2.0
 
 # CORS headers in middleware
-git+git://github.com/ottoyiu/django-cors-headers@5d5eeccf7ce#egg=django-cors-headers
+# Head includes PR #51, waiting for release
+git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
 parsimonious==0.6.2
@@ -86,7 +79,7 @@ parsimonious==0.6.2
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app
 # python3-openid >= 3.0.1 # Python 3.x - unused by app
-requests==2.5.3
+requests==2.6.0
 oauthlib==0.7.2
 requests-oauthlib==0.4.2
 django-allauth==0.19.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,37 @@
 [tox]
-envlist = py{27,34}
+envlist =
+    py{27,34},
+    docs,
+    flake8,
+    coverage
 
-[testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/webplatformcompat
-commands = python manage.py test
+[base]
 deps =
     -r{toxinidir}/requirements.txt
+
+[testenv]
+whitelist_externals = make
+commands = make test
+deps = {[base]deps}
+
+[testenv:flake8]
+deps =
+    {[base]deps}
+    flake8==2.4.0
+    flake8-docstrings==0.2.1.post1
+commands = flake8
+
+[testenv:docs]
+changedir = docs
+deps = Sphinx==1.3.1
+commands = sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[testenv:coverage]
+deps =
+    {[base]deps}
+    coverage>=3.6,<3.999
+    coveralls==0.5
+commands =
+    coverage run --source bcauth,mdn,webplatformcompat,tools setup.py test
+    coverage report -m
+    coveralls

--- a/webplatformcompat/fields.py
+++ b/webplatformcompat/fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Fields for Django models. """
+"""Fields for Django models."""
 from django_extensions.db.fields.json import JSONField
 
 from .validators import LanguageDictValidator

--- a/webplatformcompat/history.py
+++ b/webplatformcompat/history.py
@@ -50,7 +50,7 @@ class Changeset(models.Model):
 
     created = CreationDateTimeField()
     modified = ModificationDateTimeField()
-    user = models.ForeignKey(user_model)
+    user = models.ForeignKey(user_model, related_name="changesets")
     closed = models.BooleanField(
         help_text="Is the changeset closed to new changes?",
         default=False)

--- a/webplatformcompat/migrations/0005_data_add_groups.py
+++ b/webplatformcompat/migrations/0005_data_add_groups.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from itertools import chain
+
+from django.db import migrations
+
+group_perms = {
+    'change-resource': [
+        "add_changeset",
+        "change_changeset",
+        "add_browser",
+        "change_browser",
+        "add_feature",
+        "change_feature",
+        "add_maturity",
+        "change_maturity",
+        "add_section",
+        "change_section",
+        "add_specification",
+        "change_specification",
+        "add_support",
+        "change_support",
+        "add_version",
+        "change_version",
+    ],
+    'delete-resource': [
+        "add_changeset",
+        "change_changeset",
+        "delete_browser",
+        "delete_feature",
+        "delete_maturity",
+        "delete_section",
+        "delete_specification",
+        "delete_support",
+        "delete_version",
+    ]
+}
+
+
+def add_groups(apps, schema_editor, with_create_permissions=True):
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+    User = apps.get_model("auth", "User")
+
+    try:
+        perms = dict(
+            [(codename, Permission.objects.get(codename=codename))
+             for codename in set(chain(*group_perms.values()))])
+    except Permission.DoesNotExist:
+        if with_create_permissions:
+            # create_permissions runs in the post_migrate signal, at the end of
+            # all migrations. If migrating a fresh database (such as during
+            # tests), then manually run create_permissions.
+            from django.contrib.auth.management import create_permissions
+            assert not getattr(apps, 'models_module', None)
+            apps.models_module = True
+            create_permissions(apps, verbosity=0)
+            apps.models_module = None
+            return add_groups(
+                apps, schema_editor, with_create_permissions=False)
+        else:
+            raise
+
+    for group_name in sorted(group_perms.keys()):
+        group = Group.objects.create(name=group_name)
+        perm_list = [
+            perms[codename] for codename in group_perms[group_name]]
+        group.permissions.add(*perm_list)
+
+    change_group = Group.objects.get(name='change-resource')
+    for user in User.objects.all():
+        user.groups.add(change_group)
+
+
+def drop_groups(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    User = apps.get_model("auth", "User")
+
+    change_group = Group.objects.get(name='change-resource')
+    for user in User.objects.all():
+        user.groups.remove(change_group)
+
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name__in=list(group_perms.keys())).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0004_drop_field_feature_mdn_path'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_groups, drop_groups),
+    ]

--- a/webplatformcompat/migrations/0006_add_user_changesets_related_name.py
+++ b/webplatformcompat/migrations/0006_add_user_changesets_related_name.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0005_data_add_groups'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='changeset',
+            name='user',
+            field=models.ForeignKey(
+                related_name='changesets', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/webplatformcompat/migrations/0007_update_historical_models_for_1_5_4.py
+++ b/webplatformcompat/migrations/0007_update_historical_models_for_1_5_4.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+# Model changes with django-simple-history 1.5.4
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0006_add_user_changesets_related_name'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='historicalbrowser',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical browser'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalfeature',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical feature'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalmaturity',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical maturity', 'verbose_name_plural': 'historical_maturities'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalsection',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical section'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalspecification',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical specification'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalsupport',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical support'},
+        ),
+        migrations.AlterModelOptions(
+            name='historicalversion',
+            options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical version'},
+        ),
+        migrations.AlterField(
+            model_name='historicalbrowser',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalfeature',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalmaturity',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalsection',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalspecification',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalsupport',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='historicalversion',
+            name='history_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -271,10 +271,31 @@ class UserSerializer(ModelSerializer):
     """User Serializer"""
 
     created = DateField(source='date_joined', read_only=True)
+    agreement = SerializerMethodField('get_agreement')
+    permissions = SerializerMethodField('get_permissions')
+
+    def get_agreement(self, obj):
+        """What version of the contribution terms did the user agree to?
+
+        Placeholder for when we have a license agreement.
+        """
+        return 0
+
+    def get_permissions(self, obj):
+        """Return names of django.contrib.auth Groups
+
+        Can not be used with a writable view, since django.contrib.auth User
+        doesn't have this method.  Will need updating or a proxy class.
+        """
+        assert hasattr(obj, 'group_names'), "Expecting cached User object"
+        return obj.group_names
 
     class Meta:
         model = User
-        fields = ('id', 'username', 'created')
+        fields = (
+            'id', 'username', 'created', 'agreement', 'permissions',
+            'changesets')
+        read_only_fields = ('username', 'changesets')
 
 
 #

--- a/webplatformcompat/static/css/webplatformcompat.css
+++ b/webplatformcompat/static/css/webplatformcompat.css
@@ -1,0 +1,35 @@
+/* Selections from rest_framework/css/bootstrap-tweaks.css */
+
+body.api {
+  background: url("../rest_framework/img/grid.png") repeat-x;
+  background-attachment: fixed;
+}
+
+body.api #content a span {
+  text-decoration: underline;
+}
+
+/* DRF's API footer is nice enough to use everywhere */
+
+footer {
+  clear: both;
+  height: 60px;
+  width: 95%;
+  margin: 20px 2.5%;
+}
+
+footer p {
+  text-align: center;
+  color: gray;
+  border-top: 1px solid #DDDDDD;
+  padding-top: 10px;
+}
+
+footer a {
+  color: gray !important;
+  font-weight: bold;
+}
+
+footer a:hover {
+  color: gray;
+}

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -35,9 +35,10 @@ Browse.Router.map(function () {
     this.resource('support', {path: '/supports/:support_id'});
     this.resource('specifications');
     this.resource('specification', {path: '/specifications/:specification_id'});
+    this.resource('sections');
+    this.resource('section', {path: '/sections/:section_id'});
     this.resource('maturities');
     this.resource('maturity', {path: '/maturities/:maturity_id'});
-
 });
 
 /* Serializer - JsonApiSerializer with modifictions */
@@ -408,6 +409,7 @@ Browse.VersionsController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
 Browse.FeaturesController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
 Browse.SupportsController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
 Browse.SpecificationsController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
+Browse.SectionsController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
 Browse.MaturitiesController = Ember.ArrayController.extend(Browse.LoadMoreMixin);
 
 Browse.BrowserController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
@@ -582,6 +584,55 @@ Browse.SpecificationController = Ember.ObjectController.extend(Browse.LoadMoreMi
     }),
     sectionCount: Browse.Properties.IdCounter('sections'),
     sectionCountText: Browse.Properties.IdCounterText('sectionCount', 'Section'),
+});
+
+Browse.SectionController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
+    nameDefaultHTML: Browse.Properties.TranslationDefaultHTML('name'),
+    nameArray: Browse.Properties.TranslationArray('name'),
+    nameListHTML: Browse.Properties.TranslationListHTML('nameArray'),
+    noteDefaultHTML: Browse.Properties.TranslationDefaultHTML('note'),
+    noteArray: Browse.Properties.TranslationArray('note'),
+    noteListHTML: Browse.Properties.TranslationListHTML('noteArray'),
+    subpathDefaultHTML: Ember.computed('subpath', 'specification.uri', function () {
+        var subpath = this.get('subpath'),
+            specUri = this.get('specification.uri'),
+            subpathDefault;
+        if (!subpath) {
+            subpathDefault = "<em>no path</em>";
+        } else {
+            subpathDefault = subpath.en;
+        }
+        if (specUri) {
+            return '<a href="' + specUri.en + subpathDefault + '">' + subpathDefault + '</a>';
+        }
+        return subpathDefault;
+    }),
+    subpathArray: Browse.Properties.TranslationArray('subpath'),
+    subpathListHTML: Ember.computed('subpathArray', 'specification.uri', function () {
+        var subpathArray = this.get('subpathArray'),
+            specUri = this.get('specification.uri'),
+            arrayLen = subpathArray.length,
+            subpath,
+            ul = "<ul>",
+            uri,
+            i;
+        for (i = 0; i < arrayLen; i += 1) {
+            subpath = subpathArray[i];
+            if (!specUri) {
+                uri = subpath.value;
+            } else if (specUri.hasOwnProperty(subpath.lang)) {
+                uri = specUri[subpath.lang] + subpath.value;
+            } else {
+                uri = specUri.en + subpath.value;
+            }
+            ul += '<li>' + subpath.lang + ': <a href="' + uri + '">' +
+                  subpath.value + '</a></li>';
+        }
+        ul += '</ul>';
+        return ul;
+    }),
+    featureCount: Browse.Properties.IdCounter('features'),
+    featureCountText: Browse.Properties.IdCounterText('featureCount', 'Feature'),
 });
 
 Browse.MaturityController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -439,8 +439,8 @@ Browse.VersionController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
     }),
     releaseDayHTML: Browse.Properties.OptionalDateHTML('release_day'),
     retirementDayHTML: Browse.Properties.OptionalDateHTML('retirement_day'),
-    featureCount: Browse.Properties.IdCounter('supports'),
-    featureCountText: Browse.Properties.IdCounterText('featureCount', 'Feature'),
+    supportCount: Browse.Properties.IdCounter('supports'),
+    supportCountText: Browse.Properties.IdCounterText('supportCount', 'Feature'),
     releaseNoteUriArray: Browse.Properties.TranslationArray('release_notes_uri'),
     releaseNoteUriDefaultHTML: Browse.Properties.TranslationDefaultHTML('release_notes_uri'),
     releaseNoteUriListHTML: Browse.Properties.TranslationListHTML('releaseNoteUriArray'),
@@ -468,6 +468,9 @@ Browse.FeatureController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
             ul = "<ul>",
             uri,
             i;
+        if (arrayLen === 0) {
+            return "<em>none</em>";
+        }
         for (i = 0; i < arrayLen; i += 1) {
             uri = mdnArray[i];
             ul += (
@@ -496,8 +499,8 @@ Browse.FeatureController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
     nameDefaultHTML: Browse.Properties.TranslationDefaultHTML('name'),
     nameArray: Browse.Properties.TranslationArray('name'),
     nameListHTML: Browse.Properties.TranslationListHTML('nameArray'),
-    versionCount: Browse.Properties.IdCounter('supports'),
-    versionCountText: Browse.Properties.IdCounterText('versionCount', 'Version'),
+    supportCount: Browse.Properties.IdCounter('supports'),
+    supportCountText: Browse.Properties.IdCounterText('supportCount', 'Version'),
     childCount: Browse.Properties.IdCounter('children'),
     childCountText: Browse.Properties.IdCounterText('childCount', 'Child', 'Children'),
     viewUrl: Ember.computed('id', function () {
@@ -555,29 +558,24 @@ Browse.SupportController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
 });
 
 Browse.SpecificationController = Ember.ObjectController.extend(Browse.LoadMoreMixin, {
-    namesArray: Browse.Properties.TranslationArray('name'),
+    nameDefaultHTML: Browse.Properties.TranslationDefaultHTML('name'),
+    nameArray: Browse.Properties.TranslationArray('name'),
+    nameListHTML: Browse.Properties.TranslationListHTML('nameArray'),
     uriArray: Browse.Properties.TranslationArray('uri'),
-    uriDefaultHTML: Ember.computed('uri', 'name', function () {
-        var uri = this.get('uri'),
-            name = this.get('name');
-        return '<a href="' + uri.en + '">' + name.en + '</a>';
+    uriDefaultHTML: Ember.computed('uri', function () {
+        var uri = this.get('uri');
+        return '<a href="' + uri.en + '">' + uri.en + '</a>';
     }),
-    uriListHTML: Ember.computed('uriArray', 'name', function () {
+    uriListHTML: Ember.computed('uriArray', function () {
         var uriArray = this.get('uriArray'),
-            name = this.get('name'),
             arrayLen = uriArray.length,
             ul = "<ul>",
             uri,
             i;
         for (i = 0; i < arrayLen; i += 1) {
             uri = uriArray[i];
-            ul += '<li>' + uri.lang + ': <a href="' +  uri.value + '">';
-            if (name.hasOwnProperty(uri.lang)) {
-                ul += name[uri.lang];
-            } else {
-                ul += '(' + name.en + ')';
-            }
-            ul += '</a></li>';
+            ul += '<li>' + uri.lang + ': <a href="' + uri.value + '">' +
+                  uri.value + '</a></li>';
         }
         ul += '</ul>';
         return ul;
@@ -590,6 +588,8 @@ Browse.MaturityController = Ember.ObjectController.extend(Browse.LoadMoreMixin, 
     specCount: Browse.Properties.IdCounter('specifications'),
     specCountText: Browse.Properties.IdCounterText('specCount', 'Specification'),
     nameDefaultHTML: Browse.Properties.TranslationDefaultHTML('name'),
-    namesArray: Browse.Properties.TranslationArray('name'),
-    namesListHTML: Browse.Properties.TranslationListHTML('namesArray'),
+    nameArray: Browse.Properties.TranslationArray('name'),
+    nameListHTML: Browse.Properties.TranslationListHTML('nameArray'),
+    specificationCount: Browse.Properties.IdCounter('specifications'),
+    specificationCountText: Browse.Properties.IdCounterText('specificationCount', 'Specification'),
 });

--- a/webplatformcompat/templates/rest_framework/api.jinja2
+++ b/webplatformcompat/templates/rest_framework/api.jinja2
@@ -9,10 +9,11 @@
 
 {% block head_css %}
   {{ super() }}
-  <link rel="stylesheet" type="text/css" href="{{ static("rest_framework/css/bootstrap-tweaks.css") }}"/>
   <link rel="stylesheet" type="text/css" href="{{ static("rest_framework/css/prettify.css") }}"/>
   <link rel="stylesheet" type="text/css" href="{{ static("rest_framework/css/default.css") }}"/>
 {% endblock head_css %}
+
+{% block body_attr %} class="api" {% endblock %}
 
 {% block content %}
     {% block breadcrumbs %}

--- a/webplatformcompat/templates/webplatformcompat/about.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/about.jinja2
@@ -27,16 +27,16 @@
     contributions will be made to the service rather than as MDN page edits.
 </p><p>
     Some useful links:
-    <ul>
-      <li>
-        <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables">CompatibilityTables on the Mozilla Wiki</a>
-        - Project plan for the compatibility tables technology project.</li>
-      <li>
-        <a href="https://github.com/jwhitlock/web-platform-compat">web-platform-compat on Github</a>
-          - This is the primary code repository during development.</li>
-      <li>
-        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=996570">Bugzilla bug 996570</a>
-          - The tracking bug for the web-platform-compat project.</li>
-    </ul>
 </p>
+<ul>
+    <li>
+    <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables">CompatibilityTables on the Mozilla Wiki</a>
+    - Project plan for the compatibility tables technology project.</li>
+    <li>
+    <a href="https://github.com/jwhitlock/web-platform-compat">web-platform-compat on Github</a>
+        - This is the primary code repository during development.</li>
+    <li>
+    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=996570">Bugzilla bug 996570</a>
+        - The tracking bug for the web-platform-compat project.</li>
+</ul>
 {% endblock %}

--- a/webplatformcompat/templates/webplatformcompat/base.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/base.jinja2
@@ -22,7 +22,7 @@
     <![endif]-->
     {%- block head_extra %}{% endblock %}
   </head>
-  <body>
+  <body{% block body_attr%}{% endblock %}>
     {%- block navbar %}
     <nav class="navbar navbar-inverse">
       <div class="container">
@@ -80,7 +80,6 @@
           {% endif %}
         {% endblock messages %}
         {% block content %}{% endblock %}
-        <hr>
         {% block footer_elem %}
         <footer>
             <p>{% block footer %}© 2014 - {{current_year()}} Mozilla{% endblock footer %}</p>

--- a/webplatformcompat/templates/webplatformcompat/browse.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/browse.jinja2
@@ -52,6 +52,7 @@
     'features',
     'supports',
     'specifications',
+    'sections',
     'maturities',
     ] -%}
 {% set models = {
@@ -200,6 +201,30 @@
                 'linkid': 'maturity.id', 'omit': ['maturity']},
             {'name': 'Sections', 'property': 'sectionCountText',
                 'omit': ['specification']},
+        ],
+        'related': [
+            {'name': 'sections',
+                'title': '{{sectionCountText}} in this Specification'},
+        ]},
+    'sections': {
+        'detail_title': 'Section "{{{nameDefaultHTML}}}"',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Name', 'property': 'nameDefaultHTML',
+                'detail': 'nameListHTML', 'link': 'section'},
+            {'name': 'Subpath', 'property': 'subpathDefaultHTML',
+                'detail': 'subpathListHTML'},
+            {'name': 'Note', 'property': 'noteDefaultHTML',
+                'detail': 'noteListHTML'},
+            {'name': 'Specification',
+                'property': 'nameDefaultHTML',
+                'with': 'specification', 'link': 'specification'},
+            {'name': 'Features', 'property': 'featureCountText',
+                'omit': ['section']},
+        ],
+        'related': [
+            {'name': 'features',
+                'title': '{{featureCountText}} for this Section'},
         ]},
     'maturities': {
         'singular': 'maturity',

--- a/webplatformcompat/templates/webplatformcompat/browse.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/browse.jinja2
@@ -54,6 +54,8 @@
     'specifications',
     'sections',
     'maturities',
+    'users',
+    'changesets',
     ] -%}
 {% set models = {
    'browsers': {
@@ -242,6 +244,30 @@
         'related': [
             {'name': 'specifications',
                 'title': '{{specCountText}} with this maturity'},
+        ]},
+    'users': {
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Username', 'property': 'username',
+                'link': 'user'},
+            {'name': 'Created', 'property': 'createdHTML'},
+            {'name': 'Permissions', 'property': 'permissionsText'},
+            {'name': 'Changesets', 'property': 'changesetCount'},
+        ],
+        'related': [
+            {'name': 'changesets',
+                'title': '{{changesetCountText}} by this user'},
+        ]},
+    'changesets': {
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Target Resource', 'property': 'targetHTML',
+                'link': 'changeset'},
+            {'name': 'Created', 'property': 'createdHTML'},
+            {'name': 'Modified', 'property': 'modifiedHTML'},
+            {'name': 'Closed?', 'property': 'closedText'},
+            {'name': 'User', 'property': 'user.username',
+                'link': 'user', 'linkid': 'user.id', 'omit': ['user']},
         ]},
     }
 -%}

--- a/webplatformcompat/templates/webplatformcompat/browse.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/browse.jinja2
@@ -1,12 +1,11 @@
 {% extends "webplatformcompat/base.jinja2" %}
-
-{% block head_title %}Browse Web Platform Compatability Data{% endblock %}
+{% block head_title %}Browse Web Platform Compatibility Data{% endblock %}
 
 {% block body_container %}
 <script type="text/x-handlebars">
 <div class="container">
     <header>
-      <h1>Browse Web Platform Compatability Data</h1>
+      <h1>Browse Web Platform Compatibility Data</h1>
     </header>
     {{ '{{outlet}}' }}
     <footer>
@@ -16,583 +15,23 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="index">
-{% raw %}
 <p>
-    This is an application to view Web Platform Compatability Data.
+    This is an application to view Web Platform Compatibility Data.
 </p>
 <p>
     The following is available:
 </p>
 <ul>
-    <li>{{#link-to 'browsers'}}Browsers{{/link-to}}</li>
-    <li>{{#link-to 'versions'}}Versions{{/link-to}}</li>
-    <li>{{#link-to 'features'}}Features{{/link-to}}</li>
-    <li>{{#link-to 'supports'}}Supports{{/link-to}}</li>
-    <li>{{#link-to 'specifications'}}Specifications{{/link-to}}</li>
-    <li>{{#link-to 'maturities'}}Specification Maturities{{/link-to}}</li>
+    {% for name in model_order -%}
+    <li>{{ "{{#link-to '%s'}}%s{{/link-to}}" | format(name, models[name].get('title', name.title())) | safe }}</li>
+    {% endfor -%}
 </ul>
-{% endraw %}
 </script>
 
-<script type="text/x-handlebars" data-template-name="browsers">
-{% raw %}
-<h2>{{pagination.count}} Browsers</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Slug</th>
-                <th>Name</th>
-                <th>Note</th>
-                <th>Versions</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='browser'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'browser' id}}{{slug}}{{/link-to}}</td>
-                <td>{{{nameDefaultHTML}}}</td>
-                <td>{{{noteDefaultHTML}}}</td>
-                <td>{{{versionCountText}}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more browsers...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more browsers...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Browsers Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="browser">
-{% raw %}
-<h2>{{{nameDefaultHTML}}} Browser</h2>
-<p><em>back to {{#link-to 'browsers'}}Browsers{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Slug</dt>
-  <dd><code>{{slug}}</code></dd>
-  <dt>Name</dt>
-  <dd>{{{nameListHTML}}}</dd>
-  <dt>Note</dt>
-  <dd>{{{noteListHTML}}}</dd>
-</dl>
-
-<h3>{{versionCountText}} for this Browser</h3>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Version</th>
-                <th>Release Day</th>
-                <th>Retirement Day</th>
-                <th>Status</th>
-                <th>Release Notes URI</th>
-                <th>Note</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{#if versionCount}}
-          {{#each versions itemController='version'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'version' id}}{{{versionHTML}}}{{/link-to}}</td>
-                <td>{{{releaseDayHTML}}}</td>
-                <td>{{{retirementDayHTML}}}</td>
-                <td>{{status}}</td>
-                <td>{{{releaseNoteUriDefaultHTML}}}</td>
-                <td>{{{noteDefaultHTML}}}</td>
-            </tr>
-          {{else}}
-            <tr><td rowspan=0><em>Loading {{versionCountText}}...</em></td></tr>
-          {{/each}}
-        {{/if}}
-        </tbody>
-    </table>
-</div>
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="versions">
-{% raw %}
-<h2>{{pagination.count}} Versions</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Version</th>
-                <th>Release Day</th>
-                <th>Retirement Day</th>
-                <th>Status</th>
-                <th>Release Notes URI</th>
-                <th>Note</th>
-                <th>Related Features</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='version'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'version' id}}{{{fullVersionHTML}}}{{/link-to}}</td>
-                <td>{{{releaseDayHTML}}}</td>
-                <td>{{{retirementDayHTML}}}</td>
-                <td>{{status}}</td>
-                <td>{{{releaseNoteUriDefaultHTML}}}</td>
-                <td>{{{noteDefaultHTML}}}</td>
-                <td>{{#link-to 'version' id}}{{featureCountText}}{{/link-to}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more versions...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more versions...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Versions Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="version">
-{% raw %}
-<h2>{{{fullVersionHTML}}}</h2>
-<p><em>back to {{#link-to 'versions'}}Versions{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Browser</dt>
-  <dd>{{#link-to 'browser' browser.id}}{{browser.name.en}}{{/link-to}}</td>
-  <dt>Version</dt>
-  <dd>{{{versionHTML}}}</dd>
-  <dt>Release Day</dt>
-  <dd>{{{releaseDayHTML}}}</dd>
-  <dt>Retirement Day</dt>
-  <dd>{{{retirementDayHTML}}}</dd>
-  <dt>Status</dt>
-  <dd>{{status}}</dd>
-  <dt>Release Note URI</dt>
-  <dd>{{{releaseNoteUriListHTML}}}</dd>
-  <dt>Note</dt>
-  <dd>{{{noteListHTML}}}</dd>
-</dl>
-
-<h3>{{featureCountText}} with Support Info</h3>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Feature</th>
-                <th>Supported</th>
-                <th>Prefix</th>
-                <th>Alternate Name</th>
-                <th>Config</th>
-                <th>Protected</th>
-                <th>Note</th>
-                <th>Footnote</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{#if featureCount}}
-          {{#each supports itemController='support'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'feature' feature.id}}{{feature.slug}}{{/link-to}}</td>
-                <td>{{support}}</td>
-                <td>{{{prefixHTML}}}</td>
-                <td>{{{alternateNameHTML}}}</td>
-                <td>{{{requiredConfigHTML}}}</td>
-                <td>{{{protected}}}</td>
-                <td>{{{noteDefaultHTML}}}</td>
-                <td>{{{footnoteDefaultHTML}}}</td>
-            </tr>
-          {{else}}
-            <tr><td rowspan=0><em>Loading {{featureCountText}}...</em></td></tr>
-          {{/each}}
-        {{/if}}
-        </tbody>
-    </table>
-</div>
-{% endraw %}
-</script>
-
-
-<script type="text/x-handlebars" data-template-name="features">
-{% raw %}
-<h2>{{pagination.count}} Features</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Slug</th>
-                <th>Flags</th>
-                <th>Name</th>
-                <th>MDN Link</th>
-                <th>Related Versions</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='feature'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'feature' id}}{{slug}}{{/link-to}}</td>
-                <td>{{{flagsHTML}}}</td>
-                <td>{{{nameDefaultHTML}}}</td>
-                <td>{{{mdnDefaultHTML}}}</td>
-                <td>{{versionCountText}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more features...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more features...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Features Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="feature">
-{% raw %}
-<h2>Feature {{{nameDefaultHTML}}}</h2>
-<p><em>back to {{#link-to 'features'}}Features{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<p class="lead"><strong><a {{bind-attr href=viewUrl}}>View this feature with related data</a>.</strong></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Slug</dt>
-  <dd><code>{{slug}}</code></dd>
-  <dt>Experimental</dt>
-  <dd>{{experimental}}</dd>
-  <dt>Standardized</dt>
-  <dd>{{standardized}}</dd>
-  <dt>Stable</dt>
-  <dd>{{stable}}</dd>
-  <dt>Obsolete</dt>
-  <dd>{{obsolete}}</dd>
-  <dt>Name</dt>
-  <dd>{{{nameListHTML}}}</dd>
-  <dt>MDN URI</dt>
-  <dd>{{{mdnListHTML}}}</dd>
-  <dt>Parent Feature</dt>
-  <dd>{{#if parent}}{{#with parent controller='feature'}}{{#link-to 'feature' id}}{{{nameDefaultHTML}}}{{/link-to}}{{/with}}{{else}}<em>No Parent</em>{{/if}}</dd>
-  <dt>Child Features</dt>
-  <dd>
-    {{#if childCount}}
-      {{#if children}}
-      <ul>
-        {{#each children itemController='feature'}}<li>{{#link-to 'feature' id}}{{{nameDefaultHTML}}}{{/link-to}}</li>{{/each}}
-      </ul>
-      {{else}}
-      <em>Loading {{childCountText}}...</em>
-      {{/if}}
-    {{else}}
-      <em>No children</em>
-    {{/if}}
-  </dd>
-</dl>
-
-<h3>{{versionCountText}} with Support Info</h3>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Version</th>
-                <th>Supported</th>
-                <th>Prefix</th>
-                <th>Alternate Name</th>
-                <th>Requires Config</th>
-                <th>Protected</th>
-                <th>Note</th>
-                <th>Footnote</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{#if versionCount}}
-          {{#each supports itemController='support'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#with version controller='version'}}{{#link-to 'version' id}}{{{fullVersionHTML}}}{{/link-to}}{{/with}}</td>
-                <td>{{support}}</td>
-                <td>{{{prefixHTML}}}</td>
-                <td>{{{alternateNameHTML}}}</td>
-                <td>{{{requiredConfigHTML}}}</td>
-                <td>{{protected}}</td>
-                <td>{{{noteDefaultHTML}}}</td>
-                <td>{{{footnoteDefaultHTML}}}</td>
-            </tr>
-          {{else}}
-            <tr><td rowspan=0><em>Loading {{versionCountText}}...</em></td></tr>
-          {{/each}}
-        {{/if}}
-        </tbody>
-    </table>
-</div>
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="supports">
-{% raw %}
-<h2>{{pagination.count}} Supports</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Support</th>
-                <th>Version</th>
-                <th>Feature</th>
-                <th>Prefix</th>
-                <th>Alternate Name</th>
-                <th>Required Config</th>
-                <th>Protected</th>
-                <th>Note</th>
-                <th>Footnote</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='support'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'support' id}}{{support}}{{/link-to}}</td>
-                <td>{{#with version controller='version'}}{{{fullVersionHTML}}}{{/with}}</td>
-                <td>{{#with feature controller='feature'}}{{{nameDefaultHTML}}}{{/with}}</td>
-                <th>{{{prefixHTML}}}</th>
-                <th>{{{alternateNameHTML}}}</th>
-                <th>{{{requiredConfigHTML}}}</th>
-                <th>{{protected}}</th>
-                <th>{{{noteDefaultHTML}}}</th>
-                <th>{{{footnoteDefaultHTML}}}</th>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more supports...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more supports...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Supports Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="support">
-{% raw %}
-<h2>Support {{supportName}}</h2>
-<p><em>back to {{#link-to 'supports'}}Supports{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Support</dt>
-  <dd>{{support}}</dd>
-  <dt>Version</dt>
-  <dd>{{#with version controller='version'}}{{#link-to 'version' id}}{{{fullVersionHTML}}}{{/link-to}}{{/with}}</td>
-  <dt>Feature</dt>
-  <dd>{{#with feature controller='feature'}}{{#link-to 'feature' id}}{{{nameDefaultHTML}}}{{/link-to}}{{/with}}</td>
-  <dt>Prefix</dt>
-  <dd>{{{prefixHTML}}}</dd>
-  <dt>Alternate Name</dt>
-  <dd>{{{alternateNameHTML}}}</dd>
-  <dt>Required Config</dt>
-  <dd>{{{requiredConfigHTML}}}</dd>
-  <dt>Protected</dt>
-  <dd>{{{protected}}}</dd>
-  <dt>Note</dt>
-  <dd>{{{noteListHTML}}}</dd>
-  <dt>Footnote</dt>
-  <dd>{{{footnoteListHTML}}}</dd>
-</dl>
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="specifications">
-{% raw %}
-<h2>{{pagination.count}} Specifications</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Slug</th>
-                <th>MDN key</th>
-                <th>Specification URI</th>
-                <th>Maturity</th>
-                <th>Sections</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='specification'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'specification' id}}{{slug}}{{/link-to}}</td>
-                <td><code>{{mdn_key}}</code></td>
-                <td>{{{uriDefaultHTML}}}</td>
-                <td>{{#link-to 'maturity' maturity.id}}{{{maturity.name.en}}}{{/link-to}}</td>
-                <td>{{sectionCount}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more specifications...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more specifications...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Specifications Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="specification">
-{% raw %}
-<h2>Specification {{name.en}}</h2>
-<p><em>back to {{#link-to 'specifications'}}Specifications{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Slug</dt>
-  <dd><code>{{slug}}</code></dd>
-  <dt>MDN key</dt>
-  <dd><code>{{mdn_key}}</code></dd>
-  <dt>Specification URI</dt>
-  <dd>{{{uriListHTML}}}</dd>
-  <dt>Maturity</dt>
-  <dd>{{#link-to 'maturity' maturity.id}}{{maturity.name.en}}{{/link-to}}</dd>
-</dl>
-
-<h3>{{sectionCountText}} in this Specification</h3>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>title</th>
-                <th>subpath</th>
-                <th>note</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{#if sectionCount}}
-          {{#each sections}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'section' id}}{{number}} {{{name.en}}}{{/link-to}}</td>
-                <td><a {{bind-attr href=fullPath}}>{{subpath}}</a></td>
-                <td>{{#if note}}{{note.en}}{{else}}<em>none</em>{{/if}}</td>
-            </tr>
-          {{else}}
-            <tr><td rowspan=0><em>Loading {{sectionCountText}}...</em></td></tr>
-          {{/each}}
-        {{/if}}
-        </tbody>
-    </table>
-</div>
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="maturities">
-{% raw %}
-<h2>{{pagination.count}} Maturities</h2>
-<p><em>{{#link-to 'index'}}back to Index{{/link-to}}</em></p>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Slug</th>
-                <th>Maturity</th>
-                <th>Specifications</th>
-            </tr>
-        </thead>
-        <tbody>
-          {{#each itemController='maturity'}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'maturity' id}}{{slug}}{{/link-to}}</td>
-                <td>{{{nameDefaultHTML}}}</td>
-                <td>{{specCountText}}</td>
-            </tr>
-          {{/each}}
-        </tbody>
-    </table>
-</div>
-{{#if canLoadMore }}
-<button type="button" class="btn btn-default" {{action 'loadMore'}}>Load more maturities...</button>
-{{else}}{{#if loading}}
-<button type="button" class="btn btn-default" disabled="disabled">Loading more maturities...</button>
-{{else}}
-<button type="button" class="btn btn-default" disabled="disabled">All Maturities Loaded.</button>
-{{/if}}{{/if}}
-{% endraw %}
-</script>
-
-<script type="text/x-handlebars" data-template-name="maturity">
-{% raw %}
-<h2>Maturity {{name.en}}</h2>
-<p><em>back to {{#link-to 'maturities'}}Maturities{{/link-to}}, {{#link-to 'index'}}Index{{/link-to}}</em></p>
-<dl>
-  <dt>Id</dt>
-  <dd>{{id}}</dd>
-  <dt>Slug</dt>
-  <dd><code>{{slug}}</code></dd>
-  <dt>Name</dt>
-  <dd>{{{namesListHTML}}}</dd>
-</dl>
-
-<h3>{{specCountText}} with this maturity</h3>
-<div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>slug</th>
-                <th>MDN key</th>
-                <th>Specification URI</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{#if specCount}}
-          {{#each specifications}}
-            <tr>
-                <td>{{id}}</td>
-                <td>{{#link-to 'specification' id}}{{slug}}{{/link-to}}</td>
-                <td><code>{{mdn_key}}</code></td>
-                <td><a {{bind-attr href=uri.en}}>{{{name.en}}}</a></td>
-            </tr>
-          {{else}}
-            <tr><td rowspan=0><em>Loading {{specCountText}}...</em></td></tr>
-          {{/each}}
-        {{/if}}
-        </tbody>
-    </table>
-</div>
-{% endraw %}
-</script>
+{% for name in model_order -%}
+{{ index_page(name, models) }}
+{{ detail_page(name, models) }}
+{% endfor -%}
 {%- endblock body_container %}
 
 {% block body_js_extra %}
@@ -602,3 +41,301 @@
 <script src="{{ static('vendor/ember-json-api-1.0-beta.3/json_api_adapter.js')}}"></script>
 <script src="{{ static('js/browse.js') }}"></script>
 {% endblock %}
+
+{#
+ # Define the models and their attributes
+ #}
+
+{% set model_order = [
+    'browsers',
+    'versions',
+    'features',
+    'supports',
+    'specifications',
+    'maturities',
+    ] -%}
+{% set models = {
+   'browsers': {
+        'detail_title': '{{{nameDefaultHTML}}} Browser',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Slug', 'property': 'slug', 'link': 'browser',
+                'code': True},
+            {'name': 'Name', 'property': 'nameDefaultHTML',
+                'detail': 'nameListHTML'},
+            {'name': 'Note', 'property': 'noteDefaultHTML',
+                'detail': 'noteDefaultHTML'},
+            {'name': 'Versions', 'property': 'versionCountText',
+                'omit': ['browser']},
+        ],
+        'related': [
+            {'name': 'versions',
+                'title': '{{versionCountText}} for {{nameDefaultHTML}}'},
+        ]},
+    'versions': {
+        'detail_title': '{{{fullVersionHTML}}}',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Browser', 'property': 'browser.name.en',
+                'link': 'browser', 'linkid': 'browser.id',
+                'omit': ['browser', 'versions']},
+            {'name': 'Version', 'property': 'versionHTML',
+                'link': 'version', 'omit': ['version', 'versions']},
+            {'name': 'Version', 'property': 'fullVersionHTML',
+                'detail': 'versionHTML', 'link': 'version',
+                'omit': ['browser']},
+            {'name': 'Release Day', 'property': 'releaseDayHTML'},
+            {'name': 'Retirement Day',
+                'property': 'retirementDayHTML'},
+            {'name': 'Status', 'property': 'status'},
+            {'name': 'Release Notes URI',
+                'property': 'releaseNoteUriDefaultHTML',
+                'detail': 'releaseNoteUriListHTML'},
+            {'name': 'Note', 'property': 'noteDefaultHTML',
+                'detail': 'noteListHTML'},
+            {'name': 'Related Features',
+                'property': 'supportCountText', 'omit': ['version']},
+        ],
+        'related': [
+            {'name': 'supports',
+                'title': '{{supportCountText}} with Support Info'},
+        ]},
+    'features': {
+        'detail_title': 'Feature {{{nameDefaultHTML}}}',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Slug', 'property': 'slug', 'link': 'feature',
+                'code': True},
+            {'name': 'Name', 'property': 'nameDefaultHTML',
+                'detail': 'nameListHTML'},
+            {'name': 'Experimental', 'property': 'experimental',
+                'omit': ['features', 'section']},
+            {'name': 'Standardized', 'property': 'standardized',
+                'omit': ['features', 'section']},
+            {'name': 'Stable', 'property': 'stable',
+                'omit': ['features', 'section']},
+            {'name': 'Obsolete', 'property': 'obsolete',
+                'omit': ['features', 'section']},
+            {'name': 'MDN URI', 'property': 'mdnDefaultHTML',
+                'detail': 'mdnListHTML'},
+            {'name': 'Flags', 'property': 'flagsHTML',
+                'omit': ['feature']},
+            {'name': 'Related Versions',
+                'property': 'supportCountText', 'omit': ['feature']},
+        ],
+        'related': [
+            {'name': 'supports',
+                'title': '{{supportCountText}} with Support Info'},
+        ],
+        'detail_hack_nav': (
+            '<p class="lead"><strong><a {{bind-attr href=viewUrl}}>'
+            'View this feature with related data</a>.</strong></p>'),
+        'detail_hack_data': [
+            {'name': 'Parent Feature', 'raw': """
+                {{#if parent}}
+                {{#with parent controller='feature'}}
+                    {{#link-to 'feature' id}}
+                    {{{nameDefaultHTML}}}
+                    {{/link-to}}
+                {{/with}}
+                {{else}}
+                <em>No Parent</em>
+                {{/if}}"""},
+            {'name': 'Child Feature', 'raw': """
+                {{#if childCount}}
+                {{#if children}}
+                    <ul>
+                    {{#each children itemController='feature'}}<li>
+                        {{#link-to 'feature' id}}{{{nameDefaultHTML}}}{{/link-to}}
+                    </li>{{/each}}
+                    </ul>
+                {{else}}
+                    <em>Loading {{childCountText}}...</em>
+                {{/if}}
+                {{else}}
+                    <em>No children</em>
+                {{/if}}"""},
+        ]},
+    'supports': {
+        'detail_title': 'Support Details',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Supported?', 'property': 'support',
+                'link': 'support', 'omit': ['version', 'feature']},
+            {'name': 'Version', 'property': 'fullVersionHTML',
+                'with': 'version', 'link': 'version',
+                'linkid': 'version.id', 'omit': ['supports', 'version']},
+            {'name': 'Version', 'property': 'fullVersionHTML',
+                'with': 'version',
+                'omit': ['support', 'version', 'feature']},
+            {'name': 'Feature', 'property': 'feature.slug',
+                'link': 'feature', 'linkid': 'feature.id',
+                'omit': ['supports', 'feature']},
+            {'name': 'Feature', 'property': 'feature.slug',
+                'omit': ['support', 'version', 'feature']},
+            {'name': 'Supported?', 'property': 'support',
+                'omit': ['supports', 'support']},
+            {'name': 'Prefix', 'property': 'prefixHTML'},
+            {'name': 'Alternate Name',
+                'property': 'alternateNameHTML'},
+            {'name': 'Required Config',
+                'property': 'requiredConfigHTML'},
+            {'name': 'Protected', 'property': 'protected'},
+            {'name': 'Note', 'property': 'noteDefaultHTML'},
+            {'name': 'Footnote', 'property': 'footnoteDefaultHTML'},
+        ]},
+    'specifications': {
+        'detail_title': '{{{nameDefaultHTML}}} Specification',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Name', 'property': 'nameDefaultHTML',
+                'detail': 'nameListHTML', 'link': 'specification'},
+            {'name': 'Slug', 'property': 'slug', 'code': True},
+            {'name': 'MDN key', 'property': 'mdn_key', 'code': True},
+            {'name': 'Specification URI',
+                'property': 'uriDefaultHTML', 'detail': 'uriListHTML',
+                'omit': ['maturity']},
+            {'name': 'Maturity', 'property': 'maturity.name.en',
+                'html': True, 'link': 'maturity',
+                'linkid': 'maturity.id', 'omit': ['maturity']},
+            {'name': 'Sections', 'property': 'sectionCountText',
+                'omit': ['specification']},
+        ]},
+    'maturities': {
+        'singular': 'maturity',
+        'title': 'Specification Maturities',
+        'detail_title': 'Maturity "{{{nameDefaultHTML}}}"',
+        'data': [
+            {'name': 'Id', 'property': 'id'},
+            {'name': 'Slug', 'property': 'slug',
+                'link': 'maturity', 'code': True},
+            {'name': 'Name', 'property': 'nameDefaultHTML',
+                'detail': 'nameListHTML'},
+            {'name': 'Specifications', 'property': 'specCountText',
+                'omit': ['maturity']},
+        ],
+        'related': [
+            {'name': 'specifications',
+                'title': '{{specCountText}} with this maturity'},
+        ]},
+    }
+-%}
+
+{#
+ # Define the macros for generating Ember's Handlebar templates
+ #}
+
+{# Display the "Load more X" button, with loading states #}
+{% macro load_more(name) -%}
+{{ "{{#if canLoadMore }}" | safe }}
+<button type="button" class="btn btn-default" {{ "{{action 'loadMore'}}" | safe }}>Load more {{name | lower}}...</button>
+{{ "{{else}}{{#if loading}}" | safe }}
+<button type="button" class="btn btn-default" disabled="disabled">Loading more {{name | lower}}...</button>
+{{ "{{else}}" | safe }}
+<button type="button" class="btn btn-default" disabled="disabled">All {{name | title}} Loaded.</button>
+{{ "{{/if}}{{/if}}" }}
+{% endmacro %}
+
+{# Display a bound property on a Ember controller #}
+{% macro display(obj, view, detail=False) -%}
+{% if obj.get('with') -%}{{ "{{#with %s controller='%s'}}" | format(obj['with'], obj['with']) | safe }}{% endif -%}
+{% if obj.get('link') and obj['link'] != view -%}{{ "{{#link-to '%s' %s}}" | format(obj['link'], obj.get('linkid', 'id')) | safe }}
+  {%- elif obj.get('code') -%}<code>{% endif -%}
+{% if obj.get('html') or obj['property'].endswith('HTML') -%}{{ "{{{" }}{% else -%}{{ "{{" }}{% endif -%}
+{% if detail and 'detail' in obj %}{{ obj['detail'] }}{% else %}{{ obj['property'] }}{% endif %}
+{%- if obj.get('html') or obj['property'].endswith('HTML') -%}{{ "}}}" }}{% else -%}{{ "}}" }}{% endif -%}
+{% if obj.get('link') and obj['link'] != view -%}{{ "{{/link-to}}" }}
+  {%- elif obj.get('code') -%}</code>{% endif -%}
+{% if obj.get('with') -%}{{ "{{/with}}" }}{% endif -%}
+{% endmacro %}
+
+{# Display a summary table #}
+{% macro summary_table(name, model, view, through=None, as_related=False) -%}
+{% set singular = model.get('singular', name[:-1]) %}
+<div class="table-responsive">
+    <table class="table">
+        <thead>
+            <tr>
+                {% for item in model['data'] -%}
+                {% if view not in item.get('omit', []) -%}
+                <th>{% if item['name'] == 'Id' %}#{% else %}{{item['name']}}{% endif %}</th>
+                {% endif -%}
+                {% endfor -%}
+            </tr>
+        </thead>
+        <tbody>
+        {% if as_related -%}
+        {{ "{{#if %sCount}}" | format(singular) }}
+          {% if through -%}
+          {{ "{{#each %s itemController='%s'}}" | format(*through) | safe }}
+          {% else -%}
+          {{ "{{#each %s itemController='%s'}}" | format(name, singular) | safe }}
+          {% endif -%}
+        {% else -%}
+          {{ "{{#each itemController='%s'}}" | format(singular) | safe }}
+        {% endif %}
+            <tr>
+                {% for item in model['data'] -%}
+                {% if view not in item.get('omit', []) -%}
+                <td>{{ display(item, view) }}</td>
+                {% endif -%}
+                {% endfor -%}
+            </tr>
+          {% if as_related -%}
+          {{ "{{else}}" }}
+            <tr><td rowspan=0><em>Loading {{ "{{%sCountText}}" % singular }}...</em></td></tr>
+          {{ "{{/each}}" }}
+        {{ "{{/if}}" }}
+        {% else -%}
+        {{ "{{/each}}" }}
+        {% endif %}
+        </tbody>
+    </table>
+</div>
+{% if not as_related %}{{ load_more(name) }}{% endif -%}
+{% endmacro %}
+
+{# Display index page #}
+{% macro index_page(name, models) -%}
+{% set model = models[name] %}
+<script type="text/x-handlebars" data-template-name="{{name}}">
+<h2>{{ "{{pagination.count}}" }} {{ model.get('title', name.title()) }}</h2>
+<p><em>{{ "{{#link-to 'index'}}" | safe }}back to Index{{ "{{/link-to}}" }}</em></p>
+{{ summary_table(name, model, name) }}</script>
+{% endmacro %}
+
+{# Display detail page #}
+{% macro detail_page(name, models) -%}
+{% set model = models[name] %}
+{% set view = model.get('singular', name[:-1]) %}
+<script type="text/x-handlebars" data-template-name="{{view}}">
+<h2>{{model.get('detail_title', view.title() + ' {{id}}')}}</h2>
+<p><em>back to
+  {{ "{{#link-to '%s'}}%s{{/link-to}}" | format(name, name.title()) | safe }},
+  {{ "{{#link-to 'index'}}Index{{/link-to}}" | safe }}</em>
+</p>
+{% if model.get('detail_hack_nav') -%}
+{# Hack for Feature page #}
+{{ model['detail_hack_nav'] | safe }}
+{% endif -%}
+
+<dl>
+  {% for item in model['data'] -%}
+  {% if view not in item.get('omit', []) -%}
+  <dt>{{ item['name'] }}</dt>
+  <dd>{{ display(item, view, detail=True) }}</dd>
+  {% endif -%}
+  {% endfor -%}
+  {% for item in model.get('detail_hack_data', []) -%}
+  <dt>{{ item['name'] }}</dt>
+  <dd>{{ item['raw'] | safe }}</dt>
+  {% endfor -%}
+</dl>
+
+{% for item in model['related'] %}
+{% set name = item['name'] %}
+<h3>{{ item.get('title', name.title() + " for " + view.title() + ' {{id}}') }}</h2>
+{{ summary_table(name, models[name], view, through=item.get('through'), as_related=True) }}
+{%- endfor -%}
+</script>
+{% endmacro %}

--- a/webplatformcompat/templates/webplatformcompat/browse.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/browse.jinja2
@@ -9,7 +9,6 @@
       <h1>Browse Web Platform Compatability Data</h1>
     </header>
     {{ '{{outlet}}' }}
-    <hr>
     <footer>
         <p>Built on <a href="http://emberjs.com/">Ember.js</a>.  © 2014 - {{current_year()}} Mozilla</p>
     </footer>

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -39,6 +39,8 @@ class TestMixin(object):
             groups = ['change-resource']
         group_list = [Group.objects.get(name=g) for g in groups]
         user.groups.add(*group_list)
+        if 'change-resource' not in groups:
+            user.groups.remove(Group.objects.get(name='change-resource'))
         self.assertTrue(
             self.client.login(username=username, password=password))
         self.user = user

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -22,13 +22,25 @@ class TestMixin(object):
         """Create a full URL for a view"""
         return self.baseUrl + reverse(viewname, kwargs=kwargs)
 
-    def login_superuser(self):
-        """Create and login a superuser, saving to self.user"""
+    def login_user(self, groups=None):
+        """Create and login a user, saving to self.user.
+
+        groups - default groups for new users.  Defaults to ['change-resource']
+        """
+        self.assertFalse(getattr(self, 'user', None))
+        username = 'user'
+        password = 'password'
         user = User.objects.create(
-            username='staff', is_staff=True, is_superuser=True)
-        user.set_password('5T@FF')
+            username='user', is_staff=False, is_superuser=False,
+            email='user@example.com')
+        user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username='staff', password='5T@FF'))
+        if groups is None:
+            groups = ['change-resource']
+        group_list = [Group.objects.get(name=g) for g in groups]
+        user.groups.add(*group_list)
+        self.assertTrue(
+            self.client.login(username=username, password=password))
         self.user = user
         return user
 
@@ -36,8 +48,7 @@ class TestMixin(object):
         """Create a model, setting the historical relations"""
         obj = klass(**kwargs)
         obj._history_user = (
-            _history_user or getattr(self, 'user', None) or
-            self.login_superuser())
+            _history_user or getattr(self, 'user', None) or self.login_user())
 
         if not hasattr(self, 'changeset'):
             hc_kwargs = {'user': obj._history_user}

--- a/webplatformcompat/tests/test_cache.py
+++ b/webplatformcompat/tests/test_cache.py
@@ -18,6 +18,7 @@ from .base import TestCase
 class TestCache(TestCase):
     def setUp(self):
         self.cache = Cache()
+        self.login_user(groups=['change-resource'])
 
     def test_browser_v1_serializer(self):
         browser = self.create(Browser)
@@ -65,9 +66,8 @@ class TestCache(TestCase):
         self.assertEqual([], self.cache.browser_v1_invalidator(browser))
 
     def test_changeset_v1_serializer(self):
-        user = self.login_superuser()
         created = datetime(2014, 10, 29, 8, 57, 21, 806744, UTC)
-        changeset = self.create(Changeset, user=user, created=created)
+        changeset = self.create(Changeset, user=self.user, created=created)
         Changeset.objects.filter(pk=changeset.pk).update(modified=created)
         changeset = Changeset.objects.get(pk=changeset.pk)
         out = self.cache.changeset_v1_serializer(changeset)
@@ -81,7 +81,7 @@ class TestCache(TestCase):
             'user:PK': {
                 'app': u'auth',
                 'model': 'user',
-                'pk': user.pk,
+                'pk': self.user.pk,
             },
             'historical_browsers:PKList': {
                 'app': u'webplatformcompat',
@@ -125,8 +125,7 @@ class TestCache(TestCase):
         self.assertEqual(None, self.cache.changeset_v1_serializer(None))
 
     def test_changeset_v1_loader(self):
-        user = self.login_superuser()
-        changeset = self.create(Changeset, user=user)
+        changeset = self.create(Changeset, user=self.user)
         with self.assertNumQueries(8):
             obj = self.cache.changeset_v1_loader(changeset.pk)
         with self.assertNumQueries(0):
@@ -138,8 +137,7 @@ class TestCache(TestCase):
         self.assertIsNone(self.cache.changeset_v1_loader(666))
 
     def test_changeset_v1_invalidator(self):
-        user = self.login_superuser()
-        changeset = self.create(Changeset, user=user)
+        changeset = self.create(Changeset, user=self.user)
         self.assertEqual([], self.cache.changeset_v1_invalidator(changeset))
 
     def test_feature_v1_serializer(self):

--- a/webplatformcompat/tests/test_cache.py
+++ b/webplatformcompat/tests/test_cache.py
@@ -595,7 +595,7 @@ class TestCache(TestCase):
                 'model': 'changeset',
                 'pks': []
             },
-            'group_names': [],
+            'group_names': ['change-resource'],
         }
         self.assertEqual(out, expected)
 

--- a/webplatformcompat/tests/test_cache.py
+++ b/webplatformcompat/tests/test_cache.py
@@ -590,6 +590,12 @@ class TestCache(TestCase):
             'id': user.id,
             'username': '',
             'date_joined:DateTime': '1411373674.000007',
+            'changesets:PKList': {
+                'app': 'webplatformcompat',
+                'model': 'changeset',
+                'pks': []
+            },
+            'group_names': [],
         }
         self.assertEqual(out, expected)
 
@@ -605,7 +611,7 @@ class TestCache(TestCase):
 
     def test_user_v1_loader(self):
         user = self.create(User)
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(3):
             obj = self.cache.user_v1_loader(user.pk)
         with self.assertNumQueries(0):
             serialized = self.cache.user_v1_serializer(obj)

--- a/webplatformcompat/tests/test_models.py
+++ b/webplatformcompat/tests/test_models.py
@@ -92,7 +92,7 @@ class TestM2MChangedSignal(TestCase):
     def setUp(self):
         self.patcher = mock.patch(
             'webplatformcompat.tasks.update_cache_for_instance')
-        self.login_superuser()
+        self.login_user()
         self.mocked_update_cache = self.patcher.start()
         self.maturity = self.create(Maturity, slug='Foo')
         self.specification = self.create(Specification, maturity=self.maturity)

--- a/webplatformcompat/tests/test_views.py
+++ b/webplatformcompat/tests/test_views.py
@@ -51,3 +51,7 @@ class TestViews(TestCase):
         response = self.client.get(
             reverse('view_feature', kwargs={'feature_id': 1}))
         self.assertEqual(response.status_code, 200)
+
+    def test_browse_app(self):
+        response = self.client.get(reverse('browse'))
+        self.assertEqual(response.status_code, 200)

--- a/webplatformcompat/tests/test_viewset_browser.py
+++ b/webplatformcompat/tests/test_viewset_browser.py
@@ -204,7 +204,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_empty(self):
-        self.login_superuser()
+        self.login_user()
         response = self.client.post(reverse('browser-list'), {})
         self.assertEqual(400, response.status_code)
         expected_data = {
@@ -214,7 +214,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_minimal(self):
-        self.login_superuser()
+        self.login_user()
         data = {'slug': 'firefox', 'name': '{"en": "Firefox"}'}
         response = self.client.post(reverse('browser-list'), data)
         self.assertEqual(201, response.status_code, response.data)
@@ -232,7 +232,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_empty_slug_not_allowed(self):
-        self.login_superuser()
+        self.login_user()
         data = {'slug': '', 'name': '{"en": "Firefox"}'}
         response = self.client.post(reverse('browser-list'), data)
         self.assertEqual(400, response.status_code, response.data)
@@ -242,7 +242,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_whitespace_slug_not_allowed(self):
-        self.login_superuser()
+        self.login_user()
         data = {'slug': ' ', 'name': '{"en": "Firefox"}'}
         response = self.client.post(reverse('browser-list'), data)
         self.assertEqual(400, response.status_code, response.data)
@@ -254,7 +254,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_minimal_json_api(self):
-        self.login_superuser()
+        self.login_user()
         data = dumps({
             'browsers': {
                 'slug': 'firefox',
@@ -281,7 +281,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_full(self):
-        self.login_superuser()
+        self.login_user()
         data = {
             'slug': 'firefox',
             'name': '{"en": "Firefox"}',
@@ -303,7 +303,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_bad_data(self):
-        self.login_superuser()
+        self.login_user()
         data = {
             'slug': 'bad slug',
             'name': '"Firefox"',
@@ -554,6 +554,7 @@ class TestBrowserViewset(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_delete(self):
+        self.login_user(groups=["change-resource", "delete-resource"])
         browser = self.create(Browser, slug='firesux', name={'en': 'Firesux'})
         url = reverse('browser-detail', kwargs={'pk': browser.pk})
         response = self.client.delete(url)

--- a/webplatformcompat/tests/test_viewset_browser.py
+++ b/webplatformcompat/tests/test_viewset_browser.py
@@ -203,6 +203,15 @@ class TestBrowserViewset(APITestCase):
         }
         self.assertDataEqual(response.data, expected_data)
 
+    def test_post_not_allowed(self):
+        self.login_user(groups=[])
+        response = self.client.post(reverse('browser-list'), {})
+        self.assertEqual(403, response.status_code)
+        expected_data = {
+            'detail': "You do not have permission to perform this action."
+        }
+        self.assertDataEqual(response.data, expected_data)
+
     def test_post_empty(self):
         self.login_user()
         response = self.client.post(reverse('browser-list'), {})
@@ -346,6 +355,26 @@ class TestBrowserViewset(APITestCase):
             "history": [h.pk for h in histories],
             "history_current": histories[0].pk,
             "versions": [],
+        }
+        self.assertDataEqual(response.data, expected_data)
+
+    def test_put_not_allowed(self):
+        self.login_user(groups=[])
+        browser = self.create(
+            Browser, slug='browser', name={'en': 'Old Name'})
+        data = dumps({
+            'browsers': {
+                'name': {
+                    'en': 'New Name'
+                }
+            }
+        })
+        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        response = self.client.put(
+            url, data=data, content_type="application/vnd.api+json")
+        self.assertEqual(403, response.status_code)
+        expected_data = {
+            'detail': "You do not have permission to perform this action."
         }
         self.assertDataEqual(response.data, expected_data)
 
@@ -560,3 +589,15 @@ class TestBrowserViewset(APITestCase):
         response = self.client.delete(url)
         self.assertEqual(204, response.status_code, response.content)
         self.assertFalse(Browser.objects.filter(pk=browser.pk).exists())
+
+    def test_delete_not_allowed(self):
+        self.login_user()
+        browser = self.create(
+            Browser, slug='browser', name={'en': 'Old Name'})
+        url = reverse('browser-detail', kwargs={'pk': browser.pk})
+        response = self.client.delete(url)
+        self.assertEqual(403, response.status_code)
+        expected_data = {
+            'detail': "You do not have permission to perform this action."
+        }
+        self.assertDataEqual(response.data, expected_data)

--- a/webplatformcompat/tests/test_viewset_feature.py
+++ b/webplatformcompat/tests/test_viewset_feature.py
@@ -301,7 +301,7 @@ class TestFeatureViewSet(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_empty(self):
-        self.login_superuser()
+        self.login_user()
         response = self.client.post(reverse('feature-list'), {})
         self.assertEqual(400, response.status_code)
         expected_data = {

--- a/webplatformcompat/tests/test_viewset_historicalbrowser.py
+++ b/webplatformcompat/tests/test_viewset_historicalbrowser.py
@@ -15,11 +15,13 @@ from .base import APITestCase
 
 class TestHistoricalBrowserViewset(APITestCase):
 
+    def setUp(self):
+        self.user = self.login_user()
+
     def test_get(self):
-        user = self.login_superuser()
         browser = self.create(
             Browser, slug='browser', name={'en': 'A Browser'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 8, 25, 20, 50, 38, 868903, UTC))
         history = browser.history.all()[0]
         url = reverse('historicalbrowser-detail', kwargs={'pk': history.pk})
@@ -82,12 +84,11 @@ class TestHistoricalBrowserViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         self.create(
             Browser, slug='other', name={'en': 'Other Browser'})
         browser = self.create(
             Browser, slug='browser', name={'en': 'A Browser'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 9, 4, 17, 58, 26, 915222, UTC))
         history = browser.history.all()[0]
         url = reverse('historicalbrowser-list')
@@ -113,12 +114,11 @@ class TestHistoricalBrowserViewset(APITestCase):
         self.assertDataEqual(expected_data, response.data)
 
     def test_filter_by_slug(self):
-        user = self.login_superuser()
         self.create(
             Browser, slug='other', name={'en': 'Other Browser'})
         browser = self.create(
             Browser, slug='browser', name={'en': 'A Browser'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 9, 4, 17, 58, 26, 915222, UTC))
         history = browser.history.all()[0]
         url = reverse('historicalbrowser-list')

--- a/webplatformcompat/tests/test_viewset_historicalfeature.py
+++ b/webplatformcompat/tests/test_viewset_historicalfeature.py
@@ -14,12 +14,13 @@ from .base import APITestCase
 
 
 class TestHistoricalFeatureViewset(APITestCase):
+    def setUp(self):
+        self.user = self.login_user()
 
     def test_get(self):
-        user = self.login_superuser()
         feature = self.create(
             Feature, slug="the_feature", name={"en": "The Feature"},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 1, 14, 25, 14, 955097, UTC))
         history = feature.history.all()[0]
         url = reverse('historicalfeature-detail', kwargs={'pk': history.pk})
@@ -93,10 +94,9 @@ class TestHistoricalFeatureViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_get_with_sections(self):
-        user = self.login_superuser()
         feature = self.create(
             Feature, slug="the_feature", name={"en": "The Feature"},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 1, 14, 25, 14, 955097, UTC))
         maturity = self.create(Maturity, slug='Bar')
         specification = self.create(Specification, maturity=maturity)
@@ -134,11 +134,10 @@ class TestHistoricalFeatureViewset(APITestCase):
         self.assertDataEqual(expected_data, response.data)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         parent = self.create(Feature, slug="parent-feature")
         feature = self.create(
             Feature, slug="a-feature", parent=parent,
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 1, 14, 29, 33, 22803, UTC))
         history = feature.history.all()[0]
         url = reverse('historicalfeature-list')

--- a/webplatformcompat/tests/test_viewset_historicalmaturity.py
+++ b/webplatformcompat/tests/test_viewset_historicalmaturity.py
@@ -14,12 +14,13 @@ from .base import APITestCase
 
 
 class TestHistoricalMaturityViewset(APITestCase):
+    def setUp(self):
+        self.user = self.login_user()
 
     def test_get(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug="CR", name={"en": "Candidate Recommendation"},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 10, 20, 45, 609995, UTC))
         history = maturity.history.all()[0]
         url = reverse('historicalmaturity-detail', kwargs={'pk': history.pk})
@@ -79,10 +80,9 @@ class TestHistoricalMaturityViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug="PR", name={'en-US': 'Proposed Recommendation'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 10, 23, 38, 279164, UTC))
         history = maturity.history.all()[0]
         url = reverse('historicalmaturity-list')

--- a/webplatformcompat/tests/test_viewset_historicalsection.py
+++ b/webplatformcompat/tests/test_viewset_historicalsection.py
@@ -16,7 +16,6 @@ from .base import APITestCase
 class TestHistoricalSectionViewset(APITestCase):
 
     def test_get(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         spec = self.create(
@@ -26,7 +25,7 @@ class TestHistoricalSectionViewset(APITestCase):
         section = self.create(
             Section, specification=spec,
             name={'en': 'The Section'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 13, 6, 22, 602237, UTC))
         history = section.history.all()[0]
         url = reverse(
@@ -93,7 +92,6 @@ class TestHistoricalSectionViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         self.create(
@@ -105,7 +103,7 @@ class TestHistoricalSectionViewset(APITestCase):
             uri={'en': 'http://example.com/spec.html'})
         section = self.create(
             Section, specification=spec, name={'en': 'A Section'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 13, 3, 39, 223434, UTC))
 
         history = section.history.all()[0]

--- a/webplatformcompat/tests/test_viewset_historicalspecification.py
+++ b/webplatformcompat/tests/test_viewset_historicalspecification.py
@@ -16,14 +16,13 @@ from .base import APITestCase
 class TestHistoricalSpecificationViewset(APITestCase):
 
     def test_get(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         spec = self.create(
             Specification, maturity=maturity, slug="spec",
             name={'en': 'A Specification'},
             uri={'en': 'http://example.com/spec.html'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 11, 46, 10, 834522, UTC))
         history = spec.history.all()[0]
         url = reverse(
@@ -90,7 +89,6 @@ class TestHistoricalSpecificationViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         self.create(
@@ -100,7 +98,7 @@ class TestHistoricalSpecificationViewset(APITestCase):
             Specification, maturity=maturity, slug="spec",
             name={'en': 'A Specification'},
             uri={'en': 'http://example.com/spec.html'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 11, 47, 22, 595634, UTC))
         history = spec.history.all()[0]
         url = reverse('historicalspecification-list')
@@ -130,7 +128,6 @@ class TestHistoricalSpecificationViewset(APITestCase):
         self.assertDataEqual(expected_data, response.data)
 
     def test_filter_by_slug(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         self.create(
@@ -140,7 +137,7 @@ class TestHistoricalSpecificationViewset(APITestCase):
             Specification, maturity=maturity, slug="spec",
             name={'en': 'A Specification'},
             uri={'en': 'http://example.com/spec.html'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 11, 47, 22, 595634, UTC))
         history = spec.history.all()[0]
         url = reverse('historicalspecification-list')
@@ -170,7 +167,6 @@ class TestHistoricalSpecificationViewset(APITestCase):
         self.assertDataEqual(expected_data, response.data)
 
     def test_filter_by_mdn_key(self):
-        user = self.login_superuser()
         maturity = self.create(
             Maturity, slug='M', name={'en': 'A Maturity'})
         self.create(
@@ -180,7 +176,7 @@ class TestHistoricalSpecificationViewset(APITestCase):
             Specification, maturity=maturity, slug="spec", mdn_key="Spec",
             name={'en': 'A Specification'},
             uri={'en': 'http://example.com/spec.html'},
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 19, 11, 47, 22, 595634, UTC))
         history = spec.history.all()[0]
         url = reverse('historicalspecification-list')

--- a/webplatformcompat/tests/test_viewset_historicalsupport.py
+++ b/webplatformcompat/tests/test_viewset_historicalsupport.py
@@ -16,13 +16,12 @@ from .base import APITestCase
 class TestHistoricalSupportViewset(APITestCase):
 
     def test_get(self):
-        user = self.login_superuser()
         browser = self.create(Browser)
         version = self.create(Version, browser=browser)
         feature = self.create(Feature)
         support = self.create(
             Support, version=version, feature=feature,
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 7, 13, 59, 46, 86327, UTC))
         history = support.history.all()[0]
         url = reverse('historicalsupport-detail', kwargs={'pk': history.pk})
@@ -102,13 +101,12 @@ class TestHistoricalSupportViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         browser = self.create(Browser)
         version = self.create(Version, browser=browser)
         feature = self.create(Feature)
         support = self.create(
             Support, version=version, feature=feature,
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 10, 7, 14, 5, 43, 94339, UTC))
         history = support.history.all()[0]
         url = reverse('historicalsupport-list')

--- a/webplatformcompat/tests/test_viewset_historicalversion.py
+++ b/webplatformcompat/tests/test_viewset_historicalversion.py
@@ -16,12 +16,11 @@ from .base import APITestCase
 class TestHistoricalVersionViewset(APITestCase):
 
     def test_get(self):
-        user = self.login_superuser()
         browser = self.create(
             Browser, slug='browser', name={'en': 'A Browser'})
         version = self.create(
             Version, browser=browser, version="1.0",
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 9, 4, 19, 13, 25, 857510, UTC))
         history = version.history.all()[0]
         url = reverse('historicalversion-detail', kwargs={'pk': history.pk})
@@ -93,13 +92,12 @@ class TestHistoricalVersionViewset(APITestCase):
         self.assertDataEqual(expected_json, actual_json)
 
     def test_filter_by_id(self):
-        user = self.login_superuser()
         browser = self.create(
             Browser, slug='browser', name={'en': 'A Browser'})
         self.create(Version, browser=browser, version="1.0")
         version = self.create(
             Version, browser=browser, version="2.0",
-            _history_user=user,
+            _history_user=self.user,
             _history_date=datetime(2014, 9, 4, 20, 46, 28, 479175, UTC))
         history = version.history.all()[0]
         url = reverse('historicalversion-list')

--- a/webplatformcompat/tests/test_viewset_maturity.py
+++ b/webplatformcompat/tests/test_viewset_maturity.py
@@ -172,7 +172,7 @@ class TestMaturityViewSet(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_empty(self):
-        self.login_superuser()
+        self.login_user()
         response = self.client.post(reverse('maturity-list'), {})
         self.assertEqual(400, response.status_code)
         expected_data = {

--- a/webplatformcompat/tests/test_viewset_support.py
+++ b/webplatformcompat/tests/test_viewset_support.py
@@ -241,7 +241,7 @@ class TestSupportViewSet(APITestCase):
         self.assertDataEqual(response.data, expected_data)
 
     def test_post_empty(self):
-        self.login_superuser()
+        self.login_user()
         response = self.client.post(reverse('support-list'), {})
         self.assertEqual(400, response.status_code)
         expected_data = {

--- a/webplatformcompat/tests/test_viewset_user.py
+++ b/webplatformcompat/tests/test_viewset_user.py
@@ -24,6 +24,9 @@ class TestUserViewset(APITestCase):
             'id': user.pk,
             'username': 'user',
             'created': date_joined,
+            'agreement': 0,
+            'permissions': [],
+            'changesets': [],
         }
         self.assertDataEqual(response.data, expected_data)
         expected_content = {
@@ -31,6 +34,17 @@ class TestUserViewset(APITestCase):
                 "id": str(user.pk),
                 "username": 'user',
                 "created": '2014-09-04T17:10:21.827Z',
+                "agreement": 0,
+                "permissions": [],
+                "links": {"changesets": []},
+            },
+            "links": {
+                "users.changesets": {
+                    "href": (
+                        "http://testserver/api/v1/changesets/"
+                        "{users.changesets}"),
+                    "type": "changesets"
+                }
             }
         }
         actual_content = loads(response.content.decode('utf-8'))
@@ -50,5 +64,8 @@ class TestUserViewset(APITestCase):
                 'id': user.pk,
                 'username': 'user',
                 'created': date_joined,
+                'agreement': 0,
+                'permissions': [],
+                'changesets': [],
             }]}
         self.assertDataEqual(response.data, expected_data)

--- a/webplatformcompat/tests/test_viewset_user.py
+++ b/webplatformcompat/tests/test_viewset_user.py
@@ -25,7 +25,7 @@ class TestUserViewset(APITestCase):
             'username': 'user',
             'created': date_joined,
             'agreement': 0,
-            'permissions': [],
+            'permissions': ['change-resource'],
             'changesets': [],
         }
         self.assertDataEqual(response.data, expected_data)
@@ -35,7 +35,7 @@ class TestUserViewset(APITestCase):
                 "username": 'user',
                 "created": '2014-09-04T17:10:21.827Z',
                 "agreement": 0,
-                "permissions": [],
+                "permissions": ['change-resource'],
                 "links": {"changesets": []},
             },
             "links": {
@@ -65,7 +65,7 @@ class TestUserViewset(APITestCase):
                 'username': 'user',
                 'created': date_joined,
                 'agreement': 0,
-                'permissions': [],
+                'permissions': ['change-resource'],
                 'changesets': [],
             }]}
         self.assertDataEqual(response.data, expected_data)


### PR DESCRIPTION
`django.contrib.auth` is used to add action and resource API permissions, such as the ability to add a Browser, change an existing Browser, or delete a Browser.  Groups are used to gather common permissions, such as the "change-resource" group to allow add and changes of API resources.  The `user` representation is expanded to include the permissions groups as well as link to `changesets` the user has contributed.  The browse app now exposes the `section`, `user`, and `changeset` resources (but not historical resources yet).

[browsercompat.herokuapp.com](http://browsercompat.herokuapp.com/) has been updated with this code.

This commit builds on PR #22  and PR #23.  Once those are merged, this code can be rebased so it only includes the relevant commits for [bug 1063152](https://bugzilla.mozilla.org/show_bug.cgi?id=1063152).