### PR TITLE
Fix bug 1154349 - Refactor importer issues

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ source =
 omit =
     tools/client.py
     tools/download_data.py
-    tools/gather_import_errors.py
+    tools/gather_import_issues.py
     tools/import_mdn.py
     tools/integration_requests.py
     tools/load_spec_data.py

--- a/mdn/admin.py
+++ b/mdn/admin.py
@@ -1,8 +1,9 @@
 """Admin interface for mdn app."""
 from django.contrib import admin
 
-from .models import FeaturePage, PageMeta, TranslatedContent
+from .models import Issue, FeaturePage, PageMeta, TranslatedContent
 
+admin.site.register(Issue)
 admin.site.register(FeaturePage)
 admin.site.register(PageMeta)
 admin.site.register(TranslatedContent)

--- a/mdn/migrations/0003_add_issues_table.py
+++ b/mdn/migrations/0003_add_issues_table.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_extensions.db.fields.json
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0002_data_add_group'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Issue',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('slug', models.SlugField(help_text='Human-friendly slug for issue.', choices=[('false_start', 'false_start'), ('bad_json', 'bad_json'), ('halt_import', 'halt_import'), ('section_missed', 'section_missed'), ('spec_hERROR_id', 'spec_hERROR_id'), ('failed_download', 'failed_download'), ('unknown_kumascript', 'unknown_kumascript'), ('unknown_spec', 'unknown_spec'), ('spec_hERROR_name', 'spec_hERROR_name'), ('inline_text', 'inline_text'), ('footnote_multiple', 'footnote_multiple'), ('footnote_missing', 'footnote_missing'), ('footnote_feature', 'footnote_feature'), ('unknown_browser', 'unknown_browser'), ('extra_cell', 'extra_cell'), ('unknown_version', 'unknown_version'), ('spec_mismatch', 'spec_mismatch'), ('footnote_unused', 'footnote_unused'), ('exception', 'exception'), ('section_skipped', 'section_skipped'), ('compatgeckodesktop_unknown', 'compatgeckodesktop_unknown'), ('compatgeckofxos_unknown', 'compatgeckofxos_unknown'), ('footnote_no_id', 'footnote_no_id'), ('nested_p', 'nested_p'), ('compatgeckofxos_override', 'compatgeckofxos_override')])),
+                ('start', models.IntegerField(help_text='Start position in source text')),
+                ('end', models.IntegerField(help_text='End position in source text')),
+                ('params', django_extensions.db.fields.json.JSONField(help_text='Parameters for description templates')),
+                ('content', models.ForeignKey(blank=True, to='mdn.TranslatedContent', help_text='Content the issue was found on', null=True)),
+                ('page', models.ForeignKey(related_name='issues', to='mdn.FeaturePage')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.RemoveField(
+            model_name='featurepage',
+            name='has_issues',
+        ),
+    ]

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -9,10 +9,13 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.html import escape
+from django.utils.functional import cached_property
+from django.utils.six import text_type
+from django.utils.six.moves import zip
 from django.utils.six.moves.urllib_parse import urlparse
 from django.utils.timesince import timesince
 from django_extensions.db.fields import ModificationDateTimeField
+from django_extensions.db.fields.json import JSONField
 
 from webplatformcompat.models import Feature
 
@@ -60,8 +63,6 @@ class FeaturePage(models.Model):
     modified = ModificationDateTimeField(
         help_text="Last modification time", db_index=True)
     raw_data = models.TextField(help_text="JSON-encoded parsed content")
-    has_issues = models.BooleanField(
-        help_text="Issues found when parsing the page", default=False)
 
     def __str__(self):
         return "%s for %s" % (self.get_status_display(), self.slug())
@@ -112,6 +113,7 @@ class FeaturePage(models.Model):
         drop_cache - Delete cached MDN content
         """
         self.status = FeaturePage.STATUS_STARTING
+        self.issues.all().delete()
         self.reset_data()
         self.save()
         meta = self.meta()
@@ -165,11 +167,10 @@ class FeaturePage(models.Model):
                 ))),
                 ("scrape", OrderedDict((
                     ("phase", "Starting Import"),
-                    ("errors", []),
+                    ("issues", []),
                     ("raw", None)))))))))
 
         self.data = view_feature
-        self.has_issues = False
         return view_feature
 
     @property
@@ -181,6 +182,14 @@ class FeaturePage(models.Model):
             data = {}
         if not data:
             data = self.reset_data()
+
+        # Add issues
+        issues = []
+        for issue in self.issues.order_by('id'):
+            issues.append([
+                issue.slug, issue.start, issue.end, issue.params])
+        data['meta']['scrape']['issues'] = issues
+
         return data
 
     @data.setter
@@ -188,22 +197,289 @@ class FeaturePage(models.Model):
         """Serialize the data for storage"""
         self.raw_data = dumps(value, indent=2)
 
-    def add_error(self, error, safe=False):
-        """Add an error to the JSON data"""
-        data = self.data
-        errors = data['meta']['scrape']['errors']
-        if safe:
-            err = error
+    @property
+    def has_issues(self):
+        return self.issues.exists()
+
+    @cached_property
+    def issue_counts(self):
+        counts = {WARNING: 0, ERROR: 0, CRITICAL: 0}
+        for issue in self.issues.all():
+            counts[issue.severity] += 1
+        return counts
+
+    @property
+    def warnings(self):
+        return self.issue_counts[WARNING]
+
+    @property
+    def errors(self):
+        return self.issue_counts[ERROR]
+
+    @property
+    def critical(self):
+        return self.issue_counts[CRITICAL]
+
+    def add_issue(self, issue, locale=None):
+        """Add an issue to the page."""
+        slug, start, end, params = issue
+        if locale:
+            content = self.translatedcontent_set.get(locale=locale)
         else:
-            err = '<pre>%s</pre>' % escape(error)
-        if err not in errors:
-            errors.append(err)
-        self.data = data
-        self.has_issues = True
+            content = None
+
+        # Did we already add this issue?
+        if self.issues.filter(slug=slug, start=start, end=end).exists():
+            raise ValueError("Duplicate issue")
+        self.issues.create(
+            slug=slug, start=start, end=end, params=params, content=content)
+        try:
+            del self.issue_counts
+        except AttributeError:
+            pass  # Wasn't cached yet
 
     @models.permalink
     def get_absolute_url(self):
         return ('mdn.views.feature_page_detail', [str(self.id)])
+
+# Issue severity
+WARNING = 1
+ERROR = 2
+CRITICAL = 3
+SEVERITIES = {
+    WARNING: 'Warning',
+    ERROR: 'Error',
+    CRITICAL: 'Critical',
+}
+
+# Issue slugs, severity, brief templates, and long templates
+# This was a database model, but it was cumbersome to update text with a
+#  database migration, and changing slugs require code changes as well.
+ISSUES = OrderedDict((
+    ('bad_json', (
+        CRITICAL,
+        'Response from {url} is not JSON',
+        'Actual content:\n{content}')),
+    ('compatgeckodesktop_unknown', (
+        ERROR,
+        'Unknown Gecko version "{version}"',
+        'The importer does not recognize this version for CompatGeckoDesktop.'
+        ' Change the MDN page or update the importer.')),
+    ('compatgeckofxos_override', (
+        ERROR,
+        'Override "{override}" is invalid for Gecko version "{version}".',
+        'The importer does not recognize this override for CompatGeckoFxOS.'
+        ' Change the MDN page or update the importer.')),
+    ('compatgeckofxos_unknown', (
+        ERROR,
+        'Unknown Gecko version "{version}"',
+        'The importer does not recognize this version for CompatGeckoFxOS.'
+        ' Change the MDN page or update the importer.')),
+    ('exception', (CRITICAL, 'Unhandled exception', '{traceback}')),
+    ('extra_cell', (
+        ERROR,
+        'Extra cell in compatibility table row.',
+        'A row in the compatibility table has more cells than the header'
+        ' row. It may be the cell identified in the context, a different'
+        ' cell in the row, or a missing header cell.')),
+    ('failed_download', (
+        CRITICAL, 'Failed to download {url}.',
+        'Status {status}, Content:\n{text}')),
+    ('false_start', (
+        CRITICAL,
+        'No <h2> found in page.',
+        'A compatibility table must be after a proper <h2> to be imported.')),
+    ('feature_header', (
+        WARNING,
+        'Expected first header to be "Feature"',
+        'The first header is "{header}", not "Feature"')),
+    ('footnote_feature', (
+        ERROR,
+        'Footnotes are not allowed on features',
+        'The Feature model does not include a notes field. Remove the'
+        ' footnote from the feature.')),
+    ('footnote_missing', (
+        ERROR,
+        'Footnote [{footnote_id}] not found.',
+        'The compatibility table has a reference to footnote'
+        ' "{footnote_id}", but no matching footnote was found. This may'
+        ' be due to parse issues in the footnotes section, a typo in the MDN'
+        ' page, or a footnote that was removed without removing the footnote'
+        ' reference from the table.')),
+    ('footnote_multiple', (
+        ERROR,
+        'Only one footnote allowed per compatibility cell.',
+        'The API supports only one footnote per support assertion. Combine'
+        ' footnotes [{prev_footnote_id}] and [{footnote_id}], or remove'
+        ' one of them.')),
+    ('footnote_no_id', (
+        ERROR,
+        'Footnote has no ID.',
+        'Footnote references, such as [1], are used to link the footnote to'
+        ' the support assertion in the compatibility table. Reformat the MDN'
+        ' page to use footnote references.')),
+    ('footnote_unused', (
+        ERROR,
+        'Footnote [{footnote_id}] is unused.',
+        'No cells in the compatibility table included the footnote reference'
+        ' [{footnote_id}]. This could be due to a issue importing the'
+        ' compatibility cell, a typo on the MDN page, or an extra footnote'
+        ' that should be removed from the MDN page.')),
+    ('halt_import', (
+        CRITICAL,
+        'Unable to finish importing MDN page.',
+        'The importer was unable to finish parsing the MDN page. This may be'
+        ' due to a duplicated section, or other unexpected content.')),
+    ('inline_text', (
+        ERROR,
+        'Unknown inline support text "{text}".',
+        'The API schema does not include inline notes. This text needs to be'
+        ' converted to a footnote, converted to a support attribute (which'
+        ' may require an importer update), or removed.')),
+    ('nested_p', (
+        ERROR,
+        'Nested <p> tags are not supported.',
+        'Edit the MDN page to remove the nested <p> tag')),
+    ('section_skipped', (
+        CRITICAL,
+        'Section <h2>{title}</h2> has unexpected content.',
+        'The parser was trying to match rule "{rule_name}", but was unable to'
+        ' understand some unexpected content. This may be markup or'
+        ' text, or a side-effect of previous issues. Look closely at the'
+        ' context (as well as any previous issues) to find the problem'
+        ' content.')),
+    ('section_missed', (
+        CRITICAL,
+        'Section <h2>{title}</h2> was not imported.',
+        'The import of section {title} failed, but no parse error was'
+        ' detected. This is usually because of a previous critical error,'
+        ' which must be cleared before any parsing can be attempted.')),
+    ('spec_h2_id', (
+        WARNING,
+        'Expected <h2 id="Specifications">, actual id={{h2_id}}',
+        'Fix the id so that the table of contents, other feature work.')),
+    ('spec_h2_name', (
+        WARNING,
+        'Expected <h2 name="Specifications">, actual name={{h2_name}}',
+        'Fix or remove the name attribute.')),
+    ('spec_mismatch', (
+        ERROR,
+        'SpecName({specname_key}, ...) does not match'
+        ' Spec2({spec2_key}).',
+        'SpecName and Spec2 must refer to the same mdn_key. Update the MDN'
+        ' page.')),
+    ('unexpected_attribute', (
+        WARNING,
+        'Unexpected attribute <{node_type} {ident}="{value}">',
+        'For <{node_type}>, the importer is ready for the attributes'
+        ' {expected}. This unexpected attribute will be discarded.')),
+    ('unknown_browser', (
+        ERROR,
+        'Unknown Browser "{name}".',
+        'The API does not have a browser with the name "{name}".'
+        ' This could be a typo on the MDN page, or the browser needs to'
+        ' be added to the API.')),
+    ('unknown_kumascript', (
+        ERROR,
+        'Unknown KumaScript {display} in {scope}.',
+        'The importer has to run custom code to import KumaScript, and it'
+        ' hasn\'t been taught how to import {name} when it appears in a'
+        ' {scope}. File a bug, or convert the MDN page to not use this'
+        ' KumaScript macro.')),
+    ('unknown_spec', (
+        ERROR,
+        'Unknown Specification "{key}".',
+        'The API does not have a specification with mdn_key "{key}".'
+        ' This could be a typo on the MDN page, or the specfication needs to'
+        ' be added to the API.')),
+    ('unknown_version', (
+        ERROR,
+        'Unknown version "{version}" for browser "{browser_name}"',
+        'The API does not have the version "{version}" for browser'
+        ' "{browser_name}" (id {browser_id}, slug "{browser_slug}").'
+        ' This could be a typo on the MDN page, or the version needs to'
+        ' be added to the API.')),
+))
+
+
+@python_2_unicode_compatible
+class Issue(models.Model):
+    """An issue on a FeaturePage."""
+    page = models.ForeignKey(FeaturePage, related_name='issues')
+    slug = models.SlugField(
+        help_text="Human-friendly slug for issue.",
+        choices=[(slug, slug) for slug in sorted(ISSUES.keys())])
+    start = models.IntegerField(
+        help_text="Start position in source text")
+    end = models.IntegerField(
+        help_text="End position in source text")
+    params = JSONField(
+        help_text="Parameters for description templates")
+    content = models.ForeignKey(
+        'TranslatedContent', null=True, blank=True,
+        help_text="Content the issue was found on")
+
+    def __str__(self):
+        if self.content:
+            url = self.content.url()
+        else:
+            url = self.page.url
+        return "{slug} [{start}:{end}] on {url}".format(
+            slug=self.slug, start=self.start, end=self.end, url=url)
+
+    @property
+    def severity(self):
+        return ISSUES[self.slug][0]
+
+    @property
+    def brief_description(self):
+        return ISSUES[self.slug][1].format(**self.params)
+
+    @property
+    def long_description(self):
+        return ISSUES[self.slug][2].format(**self.params)
+
+    @property
+    def context(self):
+        if not self.content:
+            return ''
+
+        raw = self.content.raw
+        start_line = raw.count('\n', 0, self.start)
+        end_line = raw.count('\n', 0, self.end)
+        ctx_start_line = max(0, start_line - 2)
+        ctx_end_line = min(end_line + 3, raw.count('\n'))
+        digits = len(text_type(ctx_end_line))
+        context_lines = raw.split('\n')[ctx_start_line:ctx_end_line]
+
+        # Highlight the errored portion
+        err_page_bits = []
+        err_line_count = 1
+        for p, c in enumerate(raw):  # pragma: no branch
+            if c == '\n':
+                err_page_bits.append(c)
+                err_line_count += 1
+                if err_line_count > ctx_end_line:
+                    break
+            elif p < self.start or p >= self.end:
+                err_page_bits.append(' ')
+            else:
+                err_page_bits.append('^')
+        err_page = ''.join(err_page_bits)
+        err_lines = err_page.split('\n')[ctx_start_line:ctx_end_line]
+
+        out = []
+        for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
+            lnum = ctx_start_line + num
+            out.append(
+                text_type(lnum).rjust(digits) + ' ' + line)
+            if '^' in err_line:
+                out.append('*' * digits + ' ' + err_line)
+
+        return '\n'.join(out)
+
+    def get_severity_display(self):
+        return SEVERITIES[self.severity]
 
 
 @python_2_unicode_compatible

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -27,7 +27,6 @@ from itertools import chain
 import re
 import string
 
-from django.utils.html import escape
 from django.utils.six import text_type
 from parsimonious import IncompleteParseError, ParseError
 from parsimonious.grammar import Grammar
@@ -187,8 +186,7 @@ class PageVisitor(NodeVisitor):
     - 'compat': Data scraped from the Browser Compatibility table
     - 'footnotes': Footnotes appearing after the Browser Compatibility table,
       but not referenced in the table
-    - 'issues': Ignorable issues with the parsed page
-    - 'errors': Problems that a human should deal with.
+    - 'issues': Issues with the parsed page
     """
     def __init__(self, feature, locale='en'):
         super(PageVisitor, self).__init__()
@@ -197,7 +195,6 @@ class PageVisitor(NodeVisitor):
         self.locale = locale
         self.specs = []
         self.issues = []
-        self.errors = []
         self.compat = []
         self.footnotes = None
         self._browser_data = None
@@ -217,7 +214,6 @@ class PageVisitor(NodeVisitor):
             'specs': self.specs,
             'locale': self.locale,
             'issues': self.issues,
-            'errors': self.errors,
             'compat': self.compat,
             'footnotes': self.footnotes,
         }
@@ -251,35 +247,18 @@ class PageVisitor(NodeVisitor):
                 try:
                     page_grammar[section].parse(text)
                 except ParseError as pe:
-                    if self.errors:
-                        rule = pe.expr
-                        description = (
-                            'Section <h2>%s</h2> was not parsed.'
-                            ' The parser failed on rule "%s", but the real'
-                            ' cause is probably earlier issues. Definition:'
-                            % (title, rule.name))
-                        self.errors.append((
-                            pe.pos + start,
-                            end_of_line(pe.text, pe.pos) + start,
-                            description, rule.as_rule()))
-                    else:
-                        rule = pe.expr
-                        description = (
-                            'Section <h2>%s</h2> was not parsed. The parser'
-                            ' failed on rule "%s", but the real cause may be'
-                            ' unexpected content after this position.'
-                            ' Definition:' % (title, rule.name))
-                        self.errors.append((
-                            pe.pos + start,
-                            end_of_line(pe.text, pe.pos) + start,
-                            description, rule.as_rule()))
-
+                    expr = pe.expr
+                    self.issues.append((
+                        'section_skipped',
+                        pe.pos + start, end_of_line(pe.text, pe.pos) + start,
+                        {'rule_name': expr.name, 'title': title,
+                         'rule': expr.as_rule()}))
                 else:
-                    error = (
-                        start, end_of_line(text, 0) + start,
-                        "Section %s not parsed, probably due to earlier"
-                        " errors." % title)
-                    self.errors.append(error)
+                    self.issues.append((
+                        'section_missed',
+                        start,
+                        end_of_line(text, 0) + start,
+                        {'title': title}))
 
     visit_last_section = visit_other_section
 
@@ -296,18 +275,15 @@ class PageVisitor(NodeVisitor):
             if attr['ident'] == 'id':
                 h2_id = attr['value']
                 if h2_id not in expected:
-                    issue = (
-                        'In Specifications section, expected <h2'
-                        ' id="Specifications">, actual id=' '"%s"' % h2_id)
-                    self.issues.append((attr['start'], attr['end'], issue))
+                    self.issues.append((
+                        'spec_h2_id', attr['start'], attr['end'],
+                        {'h2_id': h2_id}))
             elif attr['ident'] == 'name':
                 h2_name = attr['value']
                 if h2_name not in expected:
-                    issue = (
-                        'In Specifications section, expected <h2'
-                        ' name="Specifications"> or no name attribute,'
-                        ' actual name="%s"' % h2_name)
-                    self.issues.append((attr['start'], attr['end'], issue))
+                    self.issues.append((
+                        'spec_h2_name', attr['start'], attr['end'],
+                        {'h2_name': h2_name}))
 
     def visit_spec_row(self, node, children):
         specname = children[2]
@@ -317,10 +293,9 @@ class PageVisitor(NodeVisitor):
         spec2_key = children[4]
         assert isinstance(spec2_key, text_type), spec2_key
         if spec2_key != key:
-            self.errors.append((
-                node.start, node.end,
-                ('SpecName(%s, ...) does not match Spec2(%s)'
-                 % (spec2_key, key))))
+            self.issues.append((
+                'spec_mismatch', node.start, node.end,
+                {'spec2_key': spec2_key, 'specname_key': key}))
             spec2_key = key
 
         desc = children[6]
@@ -357,8 +332,8 @@ class PageVisitor(NodeVisitor):
             spec = Specification.objects.get(mdn_key=key)
         except Specification.DoesNotExist:
             spec_id = None
-            self.errors.append(
-                (node.start, node.end, 'Unknown Specification "%s"' % key))
+            self.issues.append((
+                'unknown_spec', node.start, node.end, {'key': key}))
         else:
             spec_id = spec.id
         return (key, spec_id, subpath, name)
@@ -400,9 +375,9 @@ class PageVisitor(NodeVisitor):
                     try:
                         text, start, end = footnotes[f_id]
                     except KeyError:
-                        self.errors.append(
-                            (f_start, f_end,
-                             'Footnote [%s] not found' % f_id))
+                        self.issues.append((
+                            'footnote_missing', f_start, f_end,
+                            {'footnote_id': f_id}))
                     else:
                         support['footnote'] = text
                         used_footnotes.add(f_id)
@@ -411,8 +386,8 @@ class PageVisitor(NodeVisitor):
             del footnotes[f_id]
 
         for f_id, (text, start, end) in footnotes.items():
-            self.errors.append(
-                (start, end, 'Footnote [%s] not used' % f_id))
+            self.issues.append((
+                'footnote_unused', start, end, {'footnote_id': f_id}))
 
         self.compat = compat_divs
         self.footnotes = footnotes
@@ -481,8 +456,8 @@ class PageVisitor(NodeVisitor):
                 try:
                     col = table[row].index(None)
                 except ValueError:
-                    error = "Extra cell in table"
-                    self.errors.append((td['start'], cell[-1]['end'], error))
+                    self.issues.append((
+                        'extra_cell', td['start'], cell[-1]['end'], {}))
                     continue
                 rowspan = int(td.get('rowspan', 1))
                 colspan = int(td.get('colspan', 1))
@@ -527,8 +502,9 @@ class PageVisitor(NodeVisitor):
         # Verify feature header
         fcontent = feature['content']
         if fcontent['text'] != 'Feature':
-            issue = 'Expected header "Feature"'
-            self.issues.append((fcontent['start'], fcontent['end'], issue))
+            self.issues.append((
+                'feature_header', fcontent['start'], fcontent['end'],
+                {'header': fcontent['text']}))
 
         # Process client headers
         expected_attrs = ('colspan',)
@@ -542,8 +518,9 @@ class PageVisitor(NodeVisitor):
             assert isinstance(name, text_type), type(name)
             b_id, b_name, b_slug = self.browser_id_name_and_slug(name)
             if is_fake_id(b_id):
-                issue = 'Unknown Browser "%s"' % name
-                self.errors.append((content['start'], content['end'], issue))
+                self.issues.append((
+                    'unknown_browser', content['start'], content['end'],
+                    {'name': name}))
             client = {
                 'name': b_name,
                 'id': b_id,
@@ -683,8 +660,8 @@ class PageVisitor(NodeVisitor):
                 if 'footnote_id' in item:
                     footnote.append(item)
                 else:
-                    self.errors.append((
-                        item['start'], item['end'], "No ID in footnote."))
+                    self.issues.append((
+                        'footnote_no_id', item['start'], item['end'], {}))
             elif item.get('footnote_id'):
                 # New footnote
                 add_footnote(footnote)
@@ -847,10 +824,12 @@ class PageVisitor(NodeVisitor):
                 assert ident not in node_out
                 node_out[ident] = attr['value']
             else:
+                expected_text = (
+                    ', '.join(expected[:-1]) + ' or ' + expected[-1])
                 self.issues.append((
-                    attr['start'], attr['end'],
-                    "Unexpected attribute <%s %s=\"%s\">" % (
-                        node_dict['type'], ident, attr['value'])))
+                    'unexpected_attribute', attr['start'], attr['end'],
+                    {'node_type': node_dict['type'], 'ident': ident,
+                        'value': attr['value'], 'expected': expected_text}))
         return node_out
 
     def visit_th_elem(self, node, children):
@@ -915,6 +894,17 @@ class PageVisitor(NodeVisitor):
                 raise ValueError(text)
             return text[1:-1]
         return text
+
+    def unknown_kumascript_issue(self, scope, item):
+        """Create an unknown_kumascript issue."""
+        if item['args']:
+            args = '(' + ', '.join(item['args']) + ')'
+        else:
+            args = ''
+        return (
+            'unknown_kumascript', item['start'], item['end'],
+            {'name': item['name'], 'args': item['args'], 'scope': scope,
+             'display': "{{%s%s}}" % (item['name'], args)})
 
     #
     # API lookup methods
@@ -1069,18 +1059,11 @@ class PageVisitor(NodeVisitor):
                 elif kname == 'domxref':
                     name_bits.append(self.unquote(item['args'][0]))
                 else:
-                    if item['args']:
-                        args = '(' + ', '.join(item['args']) + ')'
-                    else:
-                        args = ''
-                    error = (
-                        'Unknown kumascript function %s%s'
-                        % (item['name'], args))
-                    self.errors.append((item['start'], item['end'], error))
+                    self.issues.append(self.unknown_kumascript_issue(
+                        'compatibility feature', item))
             elif item['type'] == 'footnote_id':
-                self.errors.append((
-                    item['start'], item['end'],
-                    'Footnotes are not allowed on features'))
+                self.issues.append((
+                    'footnote_feature', item['start'], item['end'], {}))
             else:
                 raise ValueError("Unknown item!", item)
         assert name_bits
@@ -1140,9 +1123,10 @@ class PageVisitor(NodeVisitor):
                 version_found = item['version']
             elif item['type'] == 'footnote_id':
                 if 'footnote_id' in support:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Only one footnote allowed.'))
+                    self.issues.append((
+                        'footnote_multiple', item['start'], item['end'],
+                        {'prev_footnote_id': support['footnote_id'][0],
+                         'footnote_id': item['footnote_id']}))
                 else:
                     support['footnote_id'] = (
                         item['footnote_id'], item['start'], item['end'])
@@ -1171,9 +1155,10 @@ class PageVisitor(NodeVisitor):
                             version_found = text_type(nversion)
                         else:
                             version_found = None
-                            self.errors.append((
+                            self.issues.append((
+                                'compatgeckodesktop_unknown',
                                 item['start'], item['end'],
-                                'Unknown Gecko version "%s"' % gversion))
+                                {'version': gversion}))
                 elif kname == 'compatgeckofxos':
                     gversion = self.unquote(item['args'][0])
                     try:
@@ -1212,14 +1197,14 @@ class PageVisitor(NodeVisitor):
                           oversion in ('', '2.2')):
                         version_found = '2.2'
                     elif nversion < 0 or nversion >= 38:
-                        self.errors.append((
-                            item['start'], item['end'],
-                            'Unknown Gecko version "%s"' % gversion))
+                        self.issues.append((
+                            'compatgeckofxos_unknown',
+                            item['start'], item['end'], {'version': gversion}))
                     else:
-                        self.errors.append((
+                        self.issues.append((
+                            'compatgeckofxos_override',
                             item['start'], item['end'],
-                            ('Override "%s" is invalid for '
-                             'Gecko version "%s"' % (oversion, gversion))))
+                            {'override': oversion, 'version': gversion}))
                 elif kname == 'compatgeckomobile':
                     gversion = self.unquote(item['args'][0])
                     version_found = gversion.split('.', 1)[0]
@@ -1228,20 +1213,13 @@ class PageVisitor(NodeVisitor):
                 elif kname in kumascript_compat_versions:
                     version_found = self.unquote(item['args'][0])
                 else:
-                    if item['args']:
-                        args = '(' + ', '.join(item['args']) + ')'
-                    else:
-                        args = ''
-                    error = (
-                        'Unknown kumascript function %s%s' %
-                        (item['name'], args))
-                    self.errors.append((item['start'], item['end'], error))
+                    self.issues.append(self.unknown_kumascript_issue(
+                        'compatibility cell', item))
             elif item['type'] == 'p_open':
                 p_depth += 1
                 if p_depth > 1:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Nested <p> tags not supported'))
+                    self.issues.append((
+                        'nested_p', item['start'], item['end'], {}))
             elif item['type'] == 'p_close' and p_depth > 1:
                 # No support for nested <p> tags
                 p_depth -= 1
@@ -1266,16 +1244,13 @@ class PageVisitor(NodeVisitor):
                 support['support'] = 'no'
             elif item['type'] == 'text':
                 if item['content']:
-                    # Inline text requires human intervention to move to a
-                    #  footnote, convert to a normal version, or remove.
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown support text "%s"' % item['content']))
+                    self.issues.append((
+                        'inline_text', item['start'], item['end'],
+                        {'text': item['content']}))
             elif item['type'] == 'code_block':
-                self.errors.append((
-                    item['start'], item['end'],
-                    'Unknown support text <code>%s</code>' %
-                    item['content']))
+                self.issues.append((
+                    'inline_text', item['start'], item['end'],
+                    {'text': '<code>{}</code>'.format(item['content'])}))
             else:
                 raise ValueError("Unknown item", item)
 
@@ -1286,12 +1261,12 @@ class PageVisitor(NodeVisitor):
                 new_version = is_fake_id(version_id)
                 new_browser = is_fake_id(browser['id'])
                 if new_version and not new_browser:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown version "%s" for browser "%s"'
-                        ' (id %d, slug "%s")' % (
-                            version_found, browser['name'], browser['id'],
-                            browser.get('slug', '<not loaded>'))))
+                    self.issues.append((
+                        'unknown_version', item['start'], item['end'],
+                        {'browser_id': browser['id'],
+                         'browser_name': browser['name'],
+                         'version': version_found,
+                         'browser_slug': browser.get('slug', '<not loaded>')}))
                 version['id'] = version_id
                 version['version'] = version_name
                 support_id = self.support_id(version_id, feature['id'])
@@ -1364,14 +1339,12 @@ class PageVisitor(NodeVisitor):
                 kumascript = "<code>%s</code>" % self.unquote(arglist[0])
             else:
                 kumascript = ""
-                if arglist:
-                    args = '(' + ', '.join(arglist) + ')'
-                else:
-                    args = ''
-                self.errors.append((
-                    start + match.start(), start + match.end(),
-                    "Unknown footnote kumascript function %s%s" %
-                    (name, args)))
+                item = {
+                    'name': name, 'args': arglist,
+                    'start': start + match.start(),
+                    'end': start + match.end()}
+                self.issues.append(self.unknown_kumascript_issue(
+                    'footnote', item))
             rendered = (
                 rendered[:match.start()] + kumascript + rendered[match.end():])
         return rendered
@@ -1384,39 +1357,22 @@ def scrape_page(mdn_page, feature, locale='en'):
         ('compat', []),
         ('footnotes', None),
         ('issues', []),
-        ('errors', []),
     ))
     if '<h2' not in mdn_page:
-        data['errors'].append('No <h2> found in page')
+        data['issues'].append(('false_start', 0, len(mdn_page), {}))
         return data
 
     try:
         page_parsed = page_grammar.parse(mdn_page)
     except IncompleteParseError as ipe:
-        error = (
-            ipe.pos, end_of_line(ipe.text, ipe.pos),
-            'Unable to finish parsing MDN page, starting at this position.')
-        data['errors'].append(error)
-        return data
-    except ParseError as pe:  # pragma: no cover
-        # TODO: Add a test once we know how to trigger
-        # Because the rules include optional sections, parse issues mostly
-        # appear as IncompleteParseError or skipping a section.  A small
-        # change to the rules may turn these into ParseErrors instead.
-        # PageVisitor.visit_other_section() handles skipped sections.
-        rule = pe.expr
-        error = (
-            pe.pos, end_of_line(pe.text, pe.pos),
-            'Rule "%s" failed to match.  Rule definition:' % rule.name,
-            rule.as_rule())
-        data['errors'].append(error)
+        data['issues'].append((
+            'halt_import', ipe.pos, end_of_line(ipe.text, ipe.pos), {}))
         return data
     page_data = PageVisitor(feature).visit(page_parsed)
 
     data['specs'] = page_data.get('specs', [])
     data['compat'] = page_data.get('compat', [])
     data['issues'] = page_data.get('issues', [])
-    data['errors'] = page_data.get('errors', [])
     data['footnotes'] = page_data.get('footnotes', None)
     return data
 
@@ -1791,12 +1747,8 @@ def scrape_feature_page(feature_page):
     feature_page.data = view_feature.generate_data()
 
     # Add issues
-    for err in chain(scraped_data['issues'], scraped_data['errors']):
-        if isinstance(err, tuple):
-            html = range_error_to_html(en_content.raw, *err)
-            feature_page.add_error(html, True)
-        else:
-            feature_page.add_error(err)
+    for issue in scraped_data['issues']:
+        feature_page.add_issue(issue, 'en-US')
 
     # Update status, issues
     feature_page.status = feature_page.STATUS_PARSED
@@ -1825,49 +1777,6 @@ def end_of_line(text, pos):
 def is_fake_id(_id):
     # Detect if an ID is a real ID
     return isinstance(_id, text_type) and _id[0] == '_'
-
-
-def range_error_to_html(page, start, end, reason, rule=None):
-    """Convert a range error to HTML"""
-    assert page, "Page can not be empty"
-    html_bits = ["<div><p>", escape(reason), "</p>"]
-    if rule:
-        html_bits.extend(("<p><code>", escape(rule), "</code></p>"))
-
-    # Get 2 lines of context around error
-    html_bits.append('<p>Context:<pre>')
-    start_line = page.count('\n', 0, start)
-    end_line = page.count('\n', 0, end)
-    ctx_start_line = max(0, start_line - 2)
-    ctx_end_line = min(end_line + 3, page.count('\n'))
-    digits = len(text_type(ctx_end_line))
-    context_lines = page.split('\n')[ctx_start_line:ctx_end_line]
-
-    # Highlight the errored portion
-    err_page_bits = []
-    err_line_count = 1
-    for p, c in enumerate(page):  # pragma: no branch
-        if c == '\n':
-            err_page_bits.append(c)
-            err_line_count += 1
-            if err_line_count > ctx_end_line:
-                break
-        elif p < start or p >= end:
-            err_page_bits.append(' ')
-        else:
-            err_page_bits.append('^')
-    err_page = ''.join(err_page_bits)
-    err_lines = err_page.split('\n')[ctx_start_line:ctx_end_line]
-
-    for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
-        lnum = ctx_start_line + num
-        html_bits.append(
-            text_type(lnum).rjust(digits) + ' ' + escape(line) + '\n')
-        if '^' in err_line:
-            html_bits.append('*' * digits + ' ' + err_line + '\n')
-
-    html_bits.append("</pre></p></div>")
-    return ''.join(html_bits)
 
 
 def slugify(word, length=50, suffix=""):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1644,6 +1644,8 @@ class ScrapedViewFeature(object):
                 ('supports', support_ids),
                 ('parent', parent_id),
                 ('children', children_ids))))))
+        if list(feature.name.keys()) == ['zxx']:
+            feature_content['name'] = feature.name['zxx']
         return feature_content
 
     def new_feature(self, feature_entry):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -615,7 +615,7 @@ class PageVisitor(NodeVisitor):
         if raw_id.isnumeric():
             footnote_id = raw_id
         else:
-            footnote_id = str(len(raw_id))
+            footnote_id = text_type(len(raw_id))
         return {
             'type': 'footnote_id',
             'footnote_id': footnote_id,
@@ -696,7 +696,7 @@ class PageVisitor(NodeVisitor):
         if raw_id.isnumeric():
             footnote_id = raw_id
         else:
-            footnote_id = str(len(raw_id))
+            footnote_id = text_type(len(raw_id))
         return footnote_id
 
     visit_footnote_p_text = _visit_content
@@ -1462,7 +1462,7 @@ class ScrapedViewFeature(object):
             else:
                 browser_content = self.load_browser(browser_entry['id'])
             self.add_resource('browsers', browser_content)
-            tab['browsers'].append(str(browser_content['id']))
+            tab['browsers'].append(text_type(browser_content['id']))
 
         # Load Features (first column)
         for feature_entry in table['features']:
@@ -1472,7 +1472,7 @@ class ScrapedViewFeature(object):
                 feature_content = self.load_feature(feature_entry['id'])
             self.add_resource_if_new('features', feature_content)
             self.compat_table_supports.setdefault(
-                str(feature_content['id']), OrderedDict())
+                text_type(feature_content['id']), OrderedDict())
 
         # Load Versions (explicit or implied in cells)
         for version_entry in table['versions']:

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -1,7 +1,7 @@
 {% extends "webplatformcompat/base.jinja2" %}
 
-{% block head_title %}Parse results for {{object.slug()}}{% endblock %}
-{% block body_title %}Parse results for {{object.slug()}}{% endblock %}
+{% block head_title %}Parse results for {{ object.slug() }}{% endblock %}
+{% block body_title %}Parse results for {{ object.slug() }}{% endblock %}
 
 {% block quick_nav %}
 <p><em>back to <a href="{{ url('feature_page_list') }}">page list</a></em></p>
@@ -10,29 +10,40 @@
 {% block content %}
 <dl>
   <dt>ID</dt>
-    <dd>{{object.id}}</dd>
+    <dd>{{ object.id }}</dd>
   <dt>MDN URL</dt>
     <dd>
-      <a id="mdn_link" href="{{object.url}}">{{object.url}}</a>
+      <a id="mdn_link" href="{{ object.url }}">{{ object.url }}</a>
       <br/>
-      (<a id="mdn_link_spec" href="{{object.url}}#Specifications">Specifications</a>,
-      <a id="mdn_link_compat" href="{{object.url}}#Browser_compatibility">Browser Compatibility</a>)
+      (<a id="mdn_link_spec" href="{{ object.url }}#Specifications">Specifications</a>,
+      <a id="mdn_link_compat" href="{{ object.url }}#Browser_compatibility">Browser Compatibility</a>)
     </dd>
   <dt>Feature ID</dt>
-    <dd><a href="/view_feature/{{object.feature_id}}">{{object.feature_id}}</a></td>
+    <dd><a href="/view_feature/{{ object.feature_id }}">{{ object.feature_id }}</a></td>
   <dt>Status</dt>
-    <dd>{{object.get_status_display()}}</dd>
+    <dd>{{ object.get_status_display() }}</dd>
   <dt>Last Modified</dt>
     <dd>{{ object.same_since() }}</dd>
   <dt>Issues</dt>
     <dd>{% if object.has_issues %}
-      <ul>
-        {% for error in object.data['meta']['scrape']['errors'] %}
-        <li>{{ error | safe }}</li>
-        {% else %}
-        <li><em><code>.has_errors</code> is set, but no errors recorded</em></li>
+      <ol>
+        {% for issue in object.issues.order_by("start") %}
+        <li><div>
+            <p>
+                <strong>{{ issue.get_severity_display() }}: {{ issue.brief_description }}</strong><br/>
+                {{ issue.long_description }}<br>
+                <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{ issue.slug }}">More information about issue "{{ issue.slug }}"</a>
+            </p>
+            {% if issue.params.rule %}
+            <p><em>Parser rule:</em></p>
+            <p><code>{{ issue.params.rule }}</code></p>
+            {% endif %}
+            {% if issue.content %}
+            <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
+            {% endif %}
+        </div></li>
         {% endfor %}
-      </ul>{% else %}
+      </ol>{% else %}
       <em>None detected</em>
       {% endif %}
     </dd>
@@ -40,7 +51,7 @@
 <h3>Actions</h3>
 <div>
 {% if can_refresh_mdn_import(request.user) %}
-<form action="{{url('feature_page_reset', pk=object.pk)}}" method="post">
+<form action="{{ url('feature_page_reset', pk=object.pk) }}" method="post">
 {{ csrf() }}
 <input id="submit-reset" class="btn btn-primary" type="submit" value="Reset">
 <label for="submit-reset">Download MDN pages and reparse</label>
@@ -48,7 +59,7 @@
 <br/>
 {% endif %}
 {% if can_reparse_mdn_import(request.user) %}
-<form id="form-reparse" action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
+<form id="form-reparse" action="{{ url('feature_page_reparse', pk=object.pk) }}" method="post">
 {{ csrf() }}
 <input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">
 <label for="submit-reparse">Re-parse the cached MDN pages</label>
@@ -57,7 +68,7 @@
 {% endif %}
 {% if can_commit_mdn_import(request.user) %}
 <form id="form-commit" class="hide"
- action="{{url('viewfeatures-detail', pk=object.feature_id)}}" method="put">
+ action="{{ url('viewfeatures-detail', pk=object.feature_id) }}" method="put">
 {{ csrf() }}
 <input id="submit-commit" class="btn btn-primary" type="submit" value="Commit">
 <label for="submit-commit">Commit data to the API</label>
@@ -71,7 +82,7 @@
 </div>
 
 {% if object.status == object.STATUS_PARSED %}
-<h1>Sample Presentation of {{object.slug()}}</h1>
+<h1>Sample Presentation of {{ object.slug() }}</h1>
 <h2>Specifications</h2>
 <div id="wpc_specifications">
   <p><i>Loading...</i></p>
@@ -95,11 +106,11 @@
 <h2>Raw Data</h2>
 <p>
   This
-  <a href="{{url('feature_page_json', pk=object.pk)}}">raw JSON-API data</a>
+  <a href="{{ url('feature_page_json', pk=object.pk) }}">raw JSON-API data</a>
   resembles that returned from
   <code>
-    <a id="wpc_uri" href="/api/v1/view_features/{{feature_id}}">
-      /api/v1/view_features/{{object.feature.id}}
+    <a id="wpc_uri" href="/api/v1/view_features/{{ feature_id }}">
+      /api/v1/view_features/{{ object.feature.id }}
     </a>
   </code>
 </p>

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -66,9 +66,9 @@
 </form>
 <br/>
 {% endif %}
-{% if can_commit_mdn_import(request.user) %}
-<form id="form-commit" class="hide"
- action="{{ url('viewfeatures-detail', pk=object.feature_id) }}" method="put">
+{% if can_commit_mdn_import(request.user) and object.errors == 0 and object.critical == 0 %}
+<form id="form-commit" method="put"
+ action="{{ url('viewfeatures-detail', pk=object.feature_id) }}">
 {{ csrf() }}
 <input id="submit-commit" class="btn btn-primary" type="submit" value="Commit">
 <label for="submit-commit">Commit data to the API</label>
@@ -219,9 +219,7 @@ function load_json(data) {
     $("#wpc_data").html(json_dump);
     window.resources = resources = WPC.parse_resources(data);
     load_tables(window.resources, "en");
-    if (data.meta.scrape.errors.length === 0) {
-        $("#form-commit").removeClass('hide').on('submit', commit_json);
-    }
+    $("#form-commit").on('submit', commit_json);
 };
 
 data = {{ object.raw_data | default('null', True) | safe }};

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -109,7 +109,7 @@
   <a href="{{ url('feature_page_json', pk=object.pk) }}">raw JSON-API data</a>
   resembles that returned from
   <code>
-    <a id="wpc_uri" href="/api/v1/view_features/{{ feature_id }}">
+    <a id="wpc_uri" href="/api/v1/view_features/{{ object.feature.id }}">
       /api/v1/view_features/{{ object.feature.id }}
     </a>
   </code>

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -4,7 +4,9 @@
 {% block body_title %}MDN Importer{% endblock %}
 
 {% block quick_nav %}
-<p><em>back to <a href="{{ url('home') }}">home</a></em></p>
+<p><em>go back to <a href="{{ url('home') }}">home</a>, or
+  see a <a href="{{ url('issues_summary') }}">summary of current issues</a>.
+</em></p>
 {% endblock %}
 
 {% block content %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<form class="form-inline" action="{{url("feature_page_search")}}" method="GET">
+<form class="form-inline" action="{{ url("feature_page_search") }}" method="GET">
   <div class="form-group">
     <label class="sr-only" for="id-url">MDN URL</label>
     <input type="url" class="form-control" id="id-url" name="url"
@@ -25,25 +25,30 @@
       <th>Feature ID</th>
       <th>MDN Slug</th>
       <th>Status</th>
-      <th>Has Issues?</th>
+      <th>Warnings /<br/>Errors /<br/>Critical Errors</th>
     </tr>
   </thead>
   <tbody>
     {% for page in page_obj.object_list %}
     <tr>
-      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.id}}</a></td>
-      <td>{{page.feature_id}}</td>
-      <td>{{page.slug()}}</td>
-      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.get_status_display()}}</a></td>
+      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{ page.id }}</a></td>
+      <td>{{ page.feature_id }}</td>
+      <td>{{ page.slug() }}</td>
+      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{ page.get_status_display() }}</a></td>
       <td>
         <a href="{{ url('feature_page_detail', pk=page.id) }}">
         {%- if page.status == page.STATUS_PARSED -%}
-          {%- if page.has_issues %}<strong>Yes</strong>{% else %}No{%endif -%}
+          {%- if page.has_issues %}
+            {{ page.warnings }} / {{ page.errors }} / {{ page.critical }}
+          {% else %}
+            No Issues
+          {% endif %}
         {%- elif page.status == page.STATUS_ERROR %}
           Scraping Failed
         {%- else %}
           <em>Still Processing</em>
         {%- endif -%}
+        </a>
       </td>
     </tr>
     {% endfor %}
@@ -55,7 +60,7 @@
 {% endif %}
 
 {% if can_create_mdn_import(request.user) %}
-<a class="btn btn-primary" href="{{url('feature_page_create')}}">Import a new page</a>
+<a class="btn btn-primary" href="{{ url('feature_page_create') }}">Import a new page</a>
 {% endif %}
 
 {% endblock content %}

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -1,0 +1,28 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}MDN Importer - {{ total_issues}} Issue{% if total_issues != 1%}s{% endif %}{% endblock %}
+{% block body_title %}MDN Importer - {{ total_issues}} Issue{% if total_issues != 1%}s{% endif %}{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to <a href="{{ url('feature_page_list') }}">list of imported pages</a></em></p>
+{% endblock %}
+
+{% block content %}
+{% if issues %}
+<ul>
+{% for count, slug, severity, brief, examples in issues %}
+  {% if count > 0 %}
+  <li>{{count}} count{% if count > 1 %}s{% endif %} of <code>{{slug}}</code> ({{severity}}): {{brief}}  Examples:
+    <ul>
+      {% for pk, mdn_url in examples %}
+      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>
+      {% endfor %}
+    </ul>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+{% else %}
+<p><i>No issues found.</i></p>
+{% endif %}
+{% endblock content %}

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1753,6 +1753,21 @@ class TestScrapedViewFeature(FeaturePageTestCase):
                 'sections': [], 'supports': []}}
         self.assertDataEqual(expected, feature_content)
 
+    def test_load_feature_canonical_name(self):
+        feature = self.create(
+            Feature, slug='web-css-background-size_list-item',
+            name={'zxx': 'list-item'}, parent=self.feature)
+        view = ScrapedViewFeature(self.page, self.empty_scrape())
+        feature_content = view.load_feature(feature.id)
+        expected = {
+            'id': str(feature.id), 'name': 'list-item',
+            'slug': feature.slug, 'mdn_uri': None, 'obsolete': False,
+            'stable': True, 'standardized': True, 'experimental': False,
+            'links': {
+                'children': [], 'parent': str(self.feature.id),
+                'sections': [], 'supports': []}}
+        self.assertDataEqual(expected, feature_content)
+
     def test_new_feature(self):
         feature_entry = {
             'id': '_feature', 'name': 'Basic support',

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -83,12 +83,13 @@ class TestFeaturePageJSONView(TestCase):
     def test_get(self):
         feature_page = FeaturePage.objects.create(
             url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
-            feature_id=741, data={"foo": "bar"})
+            feature_id=741, raw_data='{"meta": {"scrape": {"issues": []}}}')
         url = reverse('feature_page_json', kwargs={'pk': feature_page.id})
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         self.assertEqual('application/json', response['Content-Type'])
-        self.assertEqual(b'{"foo": "bar"}', response.content)
+        expected = b'{"meta": {"scrape": {"issues": []}}}'
+        self.assertEqual(expected, response.content)
 
 
 class TestFeaturePageSearch(TestCase):

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -169,3 +169,10 @@ class TestFeaturePageResetView(TestCase):
         mocked_crawl.assertCalledOnce(self.fp.pk)
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_STARTING, fp.status)
+
+
+class TestIssuesSummary(TestCase):
+    def test_get(self):
+        url = reverse('issues_summary')
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)

--- a/mdn/urls.py
+++ b/mdn/urls.py
@@ -6,6 +6,7 @@ mdn_urlpatterns = patterns(
     url(r'^$', 'feature_page_list', name='feature_page_list'),
     url(r'^create$', 'feature_page_create', name='feature_page_create'),
     url(r'^search$', 'feature_page_search', name='feature_page_search'),
+    url(r'^issues$', 'issues_summary', name='issues_summary'),
     url(r'^(?P<pk>\d+)$', 'feature_page_detail', name='feature_page_detail'),
     url(r'^(?P<pk>\d+)\.json$', 'feature_page_json', name='feature_page_json'),
     url(r'^(?P<pk>\d+)/reset$', 'feature_page_reset',

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -150,6 +150,7 @@ class FeaturePageReParse(UpdateView):
         redirect = super(FeaturePageReParse, self).form_valid(form)
         assert self.object and self.object.id
         self.object.status = FeaturePage.STATUS_PARSING
+        self.object.issues.all().delete()
         self.object.reset_data()
         self.object.save()
         messages.add_message(

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -4,12 +4,12 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, JsonResponse
-from django.views.generic import DetailView, ListView
+from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import CreateView, FormMixin, UpdateView
 
-from .models import FeaturePage, validate_mdn_url
+from .models import FeaturePage, Issue, ISSUES, SEVERITIES, validate_mdn_url
 from .tasks import start_crawl, parse_page
 
 
@@ -187,6 +187,24 @@ class FeaturePageReset(UpdateView):
         return redirect
 
 
+class IssuesSummary(TemplateView):
+    template_name = "mdn/issues_summary.jinja2"
+
+    def get_context_data(self, **kwargs):
+        ctx = super(IssuesSummary, self).get_context_data(**kwargs)
+        issues = []
+        for slug, (severity_num, brief, lengthy) in ISSUES.items():
+            severity = SEVERITIES[severity_num]
+            target = Issue.objects.filter(slug=slug)
+            count = target.count()
+            examples = set(target.values_list('page_id', 'page__url')[:10])
+            issues.append((count, slug, severity, brief, examples))
+        issues.sort(reverse=True)
+        ctx['total_issues'] = Issue.objects.count()
+        ctx['issues'] = issues
+        return ctx
+
+
 feature_page_create = user_passes_test(can_create)(
     FeaturePageCreateView.as_view())
 feature_page_detail = FeaturePageDetailView.as_view()
@@ -197,3 +215,4 @@ feature_page_reset = user_passes_test(can_refresh)(
     FeaturePageReset.as_view())
 feature_page_reparse = user_passes_test(can_refresh)(
     FeaturePageReParse.as_view())
+issues_summary = IssuesSummary.as_view()

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ celery==3.1.17
 django-mptt==0.7.1
 
 # Sorted ManyToManyField
-django-sortedm2m==0.9.4
+django-sortedm2m==0.9.5
 
 # Cached instances for Django REST Framework
 drf-cached-instances==0.3.0
@@ -73,7 +73,9 @@ drf-cached-instances==0.3.0
 git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
-parsimonious==0.6.2
+# parsimonious==0.6.2
+# TravisCI is now using ascii as system encoding, breaking setup.py
+git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 from collections import Counter
+from json import dumps
 from HTMLParser import HTMLParser
 import csv
 import logging
@@ -13,11 +14,11 @@ import time
 
 from client import Client
 
-logger = logging.getLogger('tools.gather_import_errors')
+logger = logging.getLogger('tools.gather_import_issues')
 my_dir = os.path.dirname(os.path.realpath(__file__))
 data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_errors_by_url.csv')
-BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_error_counts.csv')
+BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_issues_by_url.csv')
+BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_issue_counts.csv')
 
 
 class GatherLinks(HTMLParser):
@@ -39,33 +40,33 @@ class GatherLinks(HTMLParser):
         return ["/importer/%d.json" % i for i in sorted(self.import_ids)]
 
 
-def gather_import_errors(client, by_url_csv, by_error_csv):
-    error_rows = download_errors(client)
-    error_counts = Counter()
+def gather_import_issues(client, by_url_csv, by_issue_csv):
+    issue_rows = download_issues(client)
+    issue_counts = Counter()
 
-    # Write by-url CSV and count errors
+    # Write by-url CSV and count issues
     by_url_writer = csv.writer(by_url_csv)
     by_url_writer.writerow(
-        ["MDN Slug", "Import URL", "Source Start", "Source End", "Error",
-         "Rule"])
-    for row in error_rows:
+        ["MDN Slug", "Import URL", "Issue Slug", "Source Start", "Source End",
+         "Params"])
+    for row in issue_rows:
         err = row[4]
-        error_counts[err] += 1
+        issue_counts[err] += 1
         by_url_writer.writerow(row)
 
-    # Write by_error CSV
-    by_error_writer = csv.writer(by_error_csv)
-    by_error_writer.writerow(["Count", "Error"])
-    for err, count in error_counts.most_common():
-        by_error_writer.writerow((count, err))
+    # Write by_issue CSV
+    by_issue_writer = csv.writer(by_issue_csv)
+    by_issue_writer.writerow(["Count", "Issue"])
+    for err, count in issue_counts.most_common():
+        by_issue_writer.writerow((count, err))
 
     return {
-        'total': len(error_rows),
-        'unique': len(error_counts),
+        'total': len(issue_rows),
+        'unique': len(issue_counts),
     }
 
 
-def download_errors(client):
+def download_issues(client):
     # Gather import links
     start = time.time()
     logger.info("Gathering import URLs from %s...", client.base_url)
@@ -84,8 +85,8 @@ def download_errors(client):
     end = time.time()
     logger.info("Found %d import URLs in %0.1fs", total_urls, end - start)
 
-    # Gather errors
-    error_rows = []
+    # Gather issues
+    issue_rows = []
     start = time.time()
     for url_count, raw_url in enumerate(import_urls):
         url = client.base_url + raw_url
@@ -97,34 +98,28 @@ def download_errors(client):
         mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
         assert mdn_uri.startswith(mdn_prefix)
         mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
-        errors = resp_json['meta']['scrape']['raw']['errors']
-        for err in errors:
-            if isinstance(err, list):
-                start_pos, end_pos, msg = err[:3]
-                if len(err) == 4:
-                    rule = err[3]
-                else:
-                    rule = ""
-            else:
-                msg = err
-                start_pos = end_pos = rule = ''
-            error_rows.append(
-                (mdn_slug, human_import_url, start_pos, end_pos,
-                 msg.encode('utf-8'), rule))
+        issues = resp_json['meta']['scrape']['issues']
+        for issue in issues:
+            assert isinstance(issue, list)
+            issue_slug, start_pos, end_pos, raw_params = issue
+            params = dumps(raw_params)
+            issue_rows.append(
+                (mdn_slug, human_import_url, issue_slug, start_pos, end_pos,
+                 params))
         end = time.time()
         if (end - start) > 15:
-            percent = 100.0 * (total_urls - url_count + 1.0) / total_urls
+            percent = 100.0 * (1 - (total_urls - url_count + 1.0) / total_urls)
             logger.info(
-                "Found %d errors in %d imports (%d%%)",
-                len(error_rows), url_count + 1, percent)
+                "Found %d issues in %d imports (%d%%)",
+                len(issue_rows), url_count + 1, percent)
             start = time.time()
 
-    return error_rows
+    return issue_rows
 
 
 if __name__ == '__main__':
     import argparse
-    description = 'Gather import errors into CSVs.'
+    description = 'Gather import issues into CSVs.'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-a', '--api',
@@ -164,22 +159,22 @@ if __name__ == '__main__':
     api = args.api
     if api.endswith('/'):
         api = api[:-1]
-    logger.info("Loading importer errors from %s" % api)
+    logger.info("Loading importer issues from %s" % api)
 
     # Initialize client
     client = Client(api)
 
-    # Gather errors and write to CSVs
+    # Gather issues and write to CSVs
     counts = {}
     by_url_csv = None
-    by_error_csv = None
+    by_issue_csv = None
     try:
         by_url_csv = open(BY_URL_CSV_FILENAME, "wb")
-        by_error_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
-        counts = gather_import_errors(client, by_url_csv, by_error_csv)
+        by_issue_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
+        counts = gather_import_issues(client, by_url_csv, by_issue_csv)
     finally:
-        if by_error_csv:
-            by_error_csv.close()
+        if by_issue_csv:
+            by_issue_csv.close()
         if by_url_csv:
             by_url_csv.close()
 
@@ -187,8 +182,8 @@ if __name__ == '__main__':
         c_unique = counts.get('unique', 0)
         c_total = counts.get('total', 0)
         logger.info(
-            "Errors collected: %d unique (%d total)", c_unique, c_total)
-        logger.info("Error details in %s", BY_URL_CSV_FILENAME)
-        logger.info("Error counts in %s", BY_ERRORS_CSV_FILENAME)
+            "Issues collected: %d unique (%d total)", c_unique, c_total)
+        logger.info("Issue details in %s", BY_URL_CSV_FILENAME)
+        logger.info("Issue counts in %s", BY_ERRORS_CSV_FILENAME)
     else:
-        logger.info("No errors found.")
+        logger.info("No issues found.")

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -476,7 +476,7 @@ if __name__ == '__main__':
         password = args.password
 
     # Load data
-    with open(args.cases, 'r') as cases_file:
+    with open(args.cases, 'r', encoding='utf8') as cases_file:
         cases = json.load(cases_file, object_pairs_hook=OrderedDict)
     runner = CaseRunner(
         cases=cases, api=api, raw_dir=args.raw, mode=mode,

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -67,7 +67,7 @@ def get_compat_data(filename, url):
 
 
 def load_compat_data(client, compat_data, all_data=False, confirm=None):
-    """Load a dictionary of compatiblity data into the API"""
+    """Load a dictionary of compatibility data into the API"""
     api_collection = Collection(client)
     local_collection = Collection()
 


### PR DESCRIPTION
Several changes to handling of issues found during importing:
- Issues are stored as a slug (signifying the category of issue), plus position, extent, and context attributes, in the database and the scrape data.
- Issues are prioritized into severity levels (replacing the earlier issue/error distinction):
  - Warning - Content that can be fixed but won't stop the import process
  - Error - Content that will not be imported unless changes are made
  - Critical - Unexpected content that breaks the import process
- Issues are rendered at view time, with links to https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer, to allow adding tips for fixing issues.
- Issue counts by category are available at [/importer/issues](https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer).

https://browsercompat.herokuapp.com/importer/ has been updated to this branch, and the content reprised to populate the issues.
