### PR TITLE
Fix bug 1166875 - Drop doesitwork-dev.allizom.org

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ web-platform-compat has not been released to production yet.  The blocking
 issues for version 1 are tracked on Bugzilla_.
 
 In-progess versions are periodically deployed to Heroku at
-http://doesitwork-dev.allizom.org and https://browsercompat.herokuapp.com.
+https://browsercompat.herokuapp.com.
 
 Here are some of the development deployments:
 

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,7 @@ Development
 -----------
 
 :Code:           https://github.com/jwhitlock/web-platform-compat
-:Dev Server:     http://doesitwork-dev.allizom.org (based on `webplatform/compatibility-data`_)
-
-                 https://browsercompat.herokuapp.com (based on `jwhitlock/browsercompat-data`_)
+:Dev Server:     https://browsercompat.herokuapp.com (based on `jwhitlock/browsercompat-data`_)
 :Issues:         https://bugzilla.mozilla.org/buglist.cgi?quicksearch=compat-data (tracking bug)
 
                  https://github.com/jwhitlock/web-platform-compat/issues?state=open (documentation issues)


### PR DESCRIPTION
doesitwork-dev.allizom.org was the Heroku site that contained compat data from the [webcompat](http://github.com/webplatform/compatibility-data) project, which in turn was based on scraping MDN in summer 2014.  New development occurs on https://browsercompat.herokuapp.com, which includes data scraped from MDN directly.