### PR TITLE
Fix bug 1132658 - Scrape all MDN pages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ source =
     webplatformcompat
 omit =
     tools/client.py
+    tools/common.py
     tools/download_data.py
     tools/gather_import_issues.py
     tools/import_mdn.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ omit =
     tools/integration_requests.py
     tools/load_spec_data.py
     tools/load_webcompat_data.py
+    tools/mirror_mdn_features.py
     tools/sample_mdn.py
     tools/sync_from_api.py
     tools/upload_data.py

--- a/docs/draft/resources.rst
+++ b/docs/draft/resources.rst
@@ -313,8 +313,9 @@ The **features** representation includes:
     - **id** *(server selected)* - Database ID
     - **slug** *(write-once)* - Unique, human-friendly slug
     - **mdn_uri** *(optional, localized)* - The URI of the language-specific
-      MDN page that this feature was first scraped from.  May be used in UX or
-      for debugging import scripts.
+      MDN page that this feature was first scraped from.  If the path contains
+      unicode, it should be percent-encoded as in `RFC 3987`_. May be used in
+      UX or for debugging import scripts.
     - **experimental** - True if a feature is considered experimental, such as
       being non-standard or part of an non-ratified spec.
     - **standardized** - True if a feature is described in a standards-track
@@ -556,5 +557,6 @@ A sample response is:
 .. _non-linguistic: http://www.w3.org/International/questions/qa-no-language#nonlinguistic
 .. _`ISO 8601`: http://en.wikipedia.org/wiki/ISO_8601
 .. _MDN: https://developer.mozilla.org
+.. _RFC 3987: http://tools.ietf.org/html/rfc3987.html#section-3.1
 .. _SpecName: https://developer.mozilla.org/en-US/docs/Template:SpecName
 .. _Spec2: https://developer.mozilla.org/en-US/docs/Template:Spec2

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -100,6 +100,24 @@ tools/run_integration_tests.sh. Usage::
 * ``-q``: Be quieter
 * ``case name``: Run the listed cases, not the full suite of cases
 
+mirror_mdn_features.py
+----------------------
+Create and update API features for MDN pages.  This will create the branch
+features, and then import_mdn.py can be used to generate the leaf features.
+Usage::
+
+    $ tools/mirror_mdn_features.py [--api API] [--data DATA]
+                                   [--user USER] [--password PASSWORD]
+
+* ``--api API`` `(optional)`: Set the base URL of the API
+  (default: ``http://localhost:8000``)
+* ``--user USER``: Set the username to use for requests (default is prompt for
+  username)
+* ``--password PASSWORD``: Set the password to use for requests (default is
+  prompt for username)
+* ``--data DATA``: Set the data folder for caching MDN page JSON
+
+
 run_integration_tests.sh
 ------------------------
 Run a local API server with known data, make requests against it, and look for

--- a/mdn/admin.py
+++ b/mdn/admin.py
@@ -3,7 +3,20 @@ from django.contrib import admin
 
 from .models import Issue, FeaturePage, PageMeta, TranslatedContent
 
-admin.site.register(Issue)
-admin.site.register(FeaturePage)
-admin.site.register(PageMeta)
-admin.site.register(TranslatedContent)
+
+class IssueAdmin(admin.ModelAdmin):
+    readonly_fields = ('page', 'content')
+
+
+class FeaturePageAdmin(admin.ModelAdmin):
+    readonly_fields = ('feature',)
+
+
+class ContentAdmin(admin.ModelAdmin):
+    readonly_fields = ('page',)
+
+
+admin.site.register(Issue, IssueAdmin)
+admin.site.register(FeaturePage, FeaturePageAdmin)
+admin.site.register(PageMeta, ContentAdmin)
+admin.site.register(TranslatedContent, ContentAdmin)

--- a/mdn/migrations/0004_expand_url.py
+++ b/mdn/migrations/0004_expand_url.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0003_add_issues_table'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='translatedcontent',
+            name='title',
+            field=models.TextField(help_text='Page title in locale', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='featurepage',
+            name='status',
+            field=models.IntegerField(default=0, help_text='Status of MDN Parsing process', choices=[(0, 'Starting Import'), (1, 'Fetching Metadata'), (2, 'Fetching MDN pages'), (3, 'Parsing MDN pages'), (4, 'Parsing Complete'), (5, 'Scraping Failed'), (6, 'No Compat Data')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='slug',
+            field=models.SlugField(help_text='Human-friendly slug for issue.', choices=[('false_start', 'false_start'), ('bad_json', 'bad_json'), ('feature_header', 'feature_header'), ('section_missed', 'section_missed'), ('halt_import', 'halt_import'), ('failed_download', 'failed_download'), ('unexpected_attribute', 'unexpected_attribute'), ('unknown_spec', 'unknown_spec'), ('spec_h2_id', 'spec_h2_id'), ('spec2_arg_count', 'spec2_arg_count'), ('spec_h2_name', 'spec_h2_name'), ('inline_text', 'inline_text'), ('footnote_multiple', 'footnote_multiple'), ('footnote_missing', 'footnote_missing'), ('footnote_feature', 'footnote_feature'), ('unknown_browser', 'unknown_browser'), ('doc_parse_error', 'doc_parse_error'), ('extra_cell', 'extra_cell'), ('unknown_version', 'unknown_version'), ('spec2_wrong_kumascript', 'spec2_wrong_kumascript'), ('spec_mismatch', 'spec_mismatch'), ('footnote_unused', 'footnote_unused'), ('specname_blank_key', 'specname_blank_key'), ('exception', 'exception'), ('section_skipped', 'section_skipped'), ('compatgeckodesktop_unknown', 'compatgeckodesktop_unknown'), ('compatgeckofxos_unknown', 'compatgeckofxos_unknown'), ('footnote_no_id', 'footnote_no_id'), ('nested_p', 'nested_p'), ('unknown_kumascript', 'unknown_kumascript'), ('compatgeckofxos_override', 'compatgeckofxos_override')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pagemeta',
+            name='path',
+            field=models.CharField(help_text='Path of MDN page', max_length=1024),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='translatedcontent',
+            name='path',
+            field=models.CharField(help_text='Path of MDN page', max_length=1024),
+            preserve_default=True,
+        ),
+    ]

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -147,6 +147,8 @@ class FeaturePage(models.Model):
         for t in self.translations():
             if t.locale != 'en-US':
                 feature['mdn_uri'][t.locale] = t.url()
+        if ['zxx'] == list(feature['name'].keys()):
+            feature['name'] = feature['name']['zxx']
 
         view_feature = OrderedDict((
             ('features', feature),

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -25,7 +25,7 @@ def validate_mdn_url(value):
     disallowed_chars = '?$#'
     for c in disallowed_chars:
         if c in value:
-            raise ValidationError('"?" is not allowed in URL')
+            raise ValidationError('"{}" is not allowed in URL'.format(c))
     allowed_prefix = False
     for allowed in settings.MDN_ALLOWED_URLS:
         allowed_prefix = allowed_prefix or value.startswith(allowed)

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -49,6 +49,7 @@ class FeaturePage(models.Model):
     STATUS_PARSING = 3
     STATUS_PARSED = 4
     STATUS_ERROR = 5
+    STATUS_NO_DATA = 6
     STATUS_CHOICES = (
         (STATUS_STARTING, "Starting Import"),
         (STATUS_META, "Fetching Metadata"),
@@ -56,6 +57,7 @@ class FeaturePage(models.Model):
         (STATUS_PARSING, "Parsing MDN pages"),
         (STATUS_PARSED, "Parsing Complete"),
         (STATUS_ERROR, "Scraping Failed"),
+        (STATUS_NO_DATA, "No Compat Data"),
     )
     status = models.IntegerField(
         help_text="Status of MDN Parsing process",

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -293,7 +293,7 @@ ISSUES = OrderedDict((
         ' cell in the row, or a missing header cell.')),
     ('failed_download', (
         CRITICAL, 'Failed to download {url}.',
-        'Status {status}, Content:\n{text}')),
+        'Status {status}, Content:\n{content}')),
     ('false_start', (
         CRITICAL,
         'No <h2> found in page.',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -365,11 +365,11 @@ ISSUES = OrderedDict((
         ' which must be cleared before any parsing can be attempted.')),
     ('spec_h2_id', (
         WARNING,
-        'Expected <h2 id="Specifications">, actual id={{h2_id}}',
+        'Expected <h2 id="Specifications">, actual id={h2_id}',
         'Fix the id so that the table of contents, other feature work.')),
     ('spec_h2_name', (
         WARNING,
-        'Expected <h2 name="Specifications">, actual name={{h2_name}}',
+        'Expected <h2 name="Specifications">, actual name={h2_name}',
         'Fix or remove the name attribute.')),
     ('spec_mismatch', (
         ERROR,
@@ -388,7 +388,7 @@ ISSUES = OrderedDict((
         ' KumaScript.')),
     ('spec2_arg_count', (
         ERROR,
-        'KumaScript {kumascript} should have 1 argument',
+        'KumaScript {kumascript} should have 1 non-blank argument',
         'Argument should be the MDN key that will return a maturity')),
     ('unexpected_attribute', (
         WARNING,
@@ -412,7 +412,7 @@ ISSUES = OrderedDict((
         ERROR,
         'Unknown Specification "{key}".',
         'The API does not have a specification with mdn_key "{key}".'
-        ' This could be a typo on the MDN page, or the specfication needs to'
+        ' This could be a typo on the MDN page, or the specification needs to'
         ' be added to the API.')),
     ('unknown_version', (
         ERROR,

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -377,6 +377,19 @@ ISSUES = OrderedDict((
         ' Spec2({spec2_key}).',
         'SpecName and Spec2 must refer to the same mdn_key. Update the MDN'
         ' page.')),
+    ('specname_blank_key', (
+        ERROR,
+        'KumaScript SpecName has a blank key',
+        'Update the MDN page to include a valid mdn_key')),
+    ('spec2_wrong_kumascript', (
+        ERROR,
+        'Expected KumaScript Spec2(), got {kumascript}',
+        'Change to Spec2(mdn_key), using the mdn_key from the SpecName()'
+        ' KumaScript.')),
+    ('spec2_arg_count', (
+        ERROR,
+        'KumaScript {kumascript} should have 1 argument',
+        'Argument should be the MDN key that will return a maturity')),
     ('unexpected_attribute', (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',
@@ -390,7 +403,7 @@ ISSUES = OrderedDict((
         ' be added to the API.')),
     ('unknown_kumascript', (
         ERROR,
-        'Unknown KumaScript {display} in {scope}.',
+        'Unknown KumaScript {kumascript} in {scope}.',
         'The importer has to run custom code to import KumaScript, and it'
         ' hasn\'t been taught how to import {name} when it appears in a'
         ' {scope}. File a bug, or convert the MDN page to not use this'

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -279,6 +279,11 @@ ISSUES = OrderedDict((
         'Unknown Gecko version "{version}"',
         'The importer does not recognize this version for CompatGeckoFxOS.'
         ' Change the MDN page or update the importer.')),
+    ('doc_parse_error', (
+        CRITICAL,
+        'No imported data due to unexpected page structure.',
+        'The importer was unable to handle the page structure enough to'
+        ' determine if there was compatibility data.')),
     ('exception', (CRITICAL, 'Unhandled exception', '{traceback}')),
     ('extra_cell', (
         ERROR,

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1367,6 +1367,15 @@ def scrape_page(mdn_page, feature, locale='en'):
         data['issues'].append((
             'halt_import', ipe.pos, end_of_line(ipe.text, ipe.pos), {}))
         return data
+    except ParseError as pe:
+        if pe.expr.name == 'doc':
+            data['issues'].append((
+                'doc_parse_error', pe.pos, end_of_line(pe.text, pe.pos), {}))
+            return data
+        else:  # pragma: no cover
+            # Raise as 'exception' issue to flag for future work
+            raise pe
+
     page_data = PageVisitor(feature).visit(page_parsed)
 
     data['specs'] = page_data.get('specs', [])

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -907,9 +907,10 @@ class PageVisitor(NodeVisitor):
     def unquote(self, text):
         """Unquote strings."""
         if text.startswith('"') or text.startswith("'"):
-            if text[0] != text[-1]:
+            if text[0] == text[-1]:
+                return text[1:-1]
+            elif (text.count(text[0]) % 2) != 0:
                 raise ValueError(text)
-            return text[1:-1]
         return text
 
     def kumascript_issue(self, issue, item, scope):

--- a/mdn/tasks.py
+++ b/mdn/tasks.py
@@ -50,7 +50,7 @@ def fetch_meta(featurepage_id):
 
     # Request and validate the metadata
     url = meta.url()
-    r = requests.get(url)
+    r = requests.get(url, headers={'Cache-Control': 'no-cache'})
     next_task = None
     next_task_args = []
     if r.status_code != requests.codes.ok:
@@ -140,7 +140,7 @@ def fetch_translation(featurepage_id, locale):
 
     # Request the translation
     url = t.url() + '?raw'
-    r = requests.get(t.url() + "?raw")
+    r = requests.get(t.url() + "?raw", headers={'Cache-Control': 'no-cache'})
     t.raw = r.text
     next_task = None
     next_task_args = []

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -54,7 +54,7 @@
 <form action="{{ url('feature_page_reset', pk=object.pk) }}" method="post">
 {{ csrf() }}
 <input id="submit-reset" class="btn btn-primary" type="submit" value="Reset">
-<label for="submit-reset">Download MDN pages and reparse</label>
+<label for="submit-reset">Download MDN page and reparse</label>
 </form>
 <br/>
 {% endif %}
@@ -62,7 +62,7 @@
 <form id="form-reparse" action="{{ url('feature_page_reparse', pk=object.pk) }}" method="post">
 {{ csrf() }}
 <input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">
-<label for="submit-reparse">Re-parse the cached MDN pages</label>
+<label for="submit-reparse">Re-parse the cached MDN page</label>
 </form>
 <br/>
 {% endif %}

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -81,7 +81,7 @@
 {% endif %}
 </div>
 
-{% if object.status == object.STATUS_PARSED %}
+{% if object.status in (object.STATUS_PARSED, object.STATUS_NO_DATA) %}
 <h1>Sample Presentation of {{ object.slug() }}</h1>
 <h2>Specifications</h2>
 <div id="wpc_specifications">

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -162,7 +162,7 @@ function load_tables(resources, lang) {
         mdn_uri = "https://developer.mozilla.org/";
     }
     $("#mdn_link").attr("href", mdn_uri);
-    $("#mdn_link").text(mdn_uri);
+    $("#mdn_link").text(decodeURIComponent(mdn_uri));
     $("#mdn_link_spec").attr("href", mdn_uri + "#Specifications")
     $("#mdn_link_compat").attr("href", mdn_uri + "#Browser_compatibility")
 

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -45,8 +45,10 @@
           {% else %}
             No Issues
           {% endif %}
+        {%- elif page.status == page.STATUS_NO_DATA %}
+          No Data
         {%- elif page.status == page.STATUS_ERROR %}
-          Scraping Failed
+          <strong>Scraping Failed</strong>
         {%- else %}
           <em>Still Processing</em>
         {%- endif -%}

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -12,7 +12,9 @@
 <ul>
 {% for count, slug, severity, brief, examples in issues %}
   {% if count > 0 %}
-  <li>{{count}} count{% if count > 1 %}s{% endif %} of <code>{{slug}}</code> ({{severity}}): {{brief}}  Examples:
+  <li>{{count}} count{% if count > 1 %}s{% endif %} of
+      <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}"><code>{{slug}}</code></a>
+      ({{severity}}): {{brief}}  Example{% if count != 0 %}s{% endif %}:
     <ul>
       {% for pk, mdn_url in examples %}
       <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -112,6 +112,11 @@ class TestFeaturePageModel(TestCase):
         t_de = TranslatedContent.objects.get(page=self.fp, locale='de')
         self.assertEqual(t_de.status, PageMeta.STATUS_STARTING)
 
+    def test_get_data_canonical(self):
+        self.fp.feature.name = {'zxx': 'canonical'}
+        data = self.fp.data
+        self.assertEqual('canonical', data['features']['name'])
+
     def test_get_data_existing(self):
         self.fp.raw_data = '{"meta": {"scrape": {"issues": "x"}}}'
         expected = {"meta": {"scrape": {"issues": []}}}

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -46,9 +46,11 @@ class TestFeaturePageModel(TestCase):
         self.metadata = {
             "locale": "en-US",
             "url": "https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            "title": "<float>",
             "translations": [{
                 "locale": "de",
                 "url": "https://developer.mozilla.org/de/docs/Web/CSS/float",
+                "title": "<float>",
             }],
         }
 
@@ -86,10 +88,10 @@ class TestFeaturePageModel(TestCase):
             page=self.fp, path='/foo/path', status=PageMeta.STATUS_FETCHED,
             raw=dumps(self.metadata))
         TranslatedContent.objects.create(
-            page=self.fp, locale='en', path='/foo/en/path',
+            page=self.fp, locale='en', path='/foo/en/path', title='title',
             status=PageMeta.STATUS_FETCHED, raw="Black, White, Yellow, Red")
         TranslatedContent.objects.create(
-            page=self.fp, locale='de', path='/foo/de/path',
+            page=self.fp, locale='de', path='/foo/de/path', title='title',
             status=PageMeta.STATUS_ERROR, raw="Schwarz, Weiß, Gelb, Rot")
 
     def test_reset(self):
@@ -259,17 +261,22 @@ class TestPageMetaModel(TestCase):
         data = {
             'locale': 'en-US',
             'url': 'https://developer.mozilla.org/en-US/docs/Web/CSS/display',
+            'title': 'display',
             'translations': [{
                 'locale': 'es',
                 'url': 'https://developer.mozilla.org/es/docs/Web/CSS/display',
+                'title': 'display',
             }],
         }
         self.meta.status = self.meta.STATUS_FETCHED
         self.meta.raw = dumps(data)
         expected = [
             ('en-US',
-             'https://developer.mozilla.org/en-US/docs/Web/CSS/display'),
-            ('es', 'https://developer.mozilla.org/es/docs/Web/CSS/display'),
+             'https://developer.mozilla.org/en-US/docs/Web/CSS/display',
+             'display'),
+            ('es',
+             'https://developer.mozilla.org/es/docs/Web/CSS/display',
+             'display'),
         ]
         self.assertEqual(expected, self.meta.locale_paths())
 
@@ -281,8 +288,7 @@ class TestTranslatedContentModel(TestCase):
             feature_id=666,
             status=FeaturePage.STATUS_PARSED)
         self.c = TranslatedContent(
-            page=fp,
-            locale="de",
+            page=fp, locale="de", title='<float>',
             path="/de/docs/Web/CSS/float")
 
     def test_str(self):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1507,6 +1507,11 @@ class TestPageVisitor(ScrapeTestCase):
     def test_unquote_unbalanced(self):
         self.assertRaises(ValueError, self.visitor.unquote, "'Mixed\"")
 
+    def test_unquote_quote_plus_text(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-zoom
+        text = '"max-zoom" descriptor'
+        self.assertEqual(text, self.visitor.unquote(text))
+
     def assert_browser_lookup(self, name, browser_id, fixed_name, slug):
         lookup = self.visitor.browser_id_name_and_slug(name)
         self.assertEqual(browser_id, lookup[0])

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1544,6 +1544,10 @@ class TestScrape(ScrapeTestCase):
         page = "<h2>Incomplete</h2><p>Incomplete</p>"
         self.assertScrape(page, [], [('halt_import', 0, 36, {})])
 
+    def test_not_compat_page(self):
+        page = "<h3>I'm not a compat page</h3>"
+        self.assertScrape(page, [], [('doc_parse_error', 0, 30, {})])
+
     def test_spec_only(self):
         """Test with a only a Specification section."""
         page = self.sample_spec_section

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1618,11 +1618,11 @@ class FeaturePageTestCase(ScrapeTestCase):
             url=url, feature=self.feature, status=FeaturePage.STATUS_PARSING)
         meta = self.page.meta()
         meta.raw = dumps({
-            'locale': 'en-US',
-            'url': path,
+            'locale': 'en-US', 'url': path, 'title': 'background-size',
             'translations': [{
                 'locale': 'fr',
-                'url': path.replace('en-US', 'fr')
+                'url': path.replace('en-US', 'fr'),
+                'title': 'background-size',
             }]})
         meta.status = meta.STATUS_FETCHED
         meta.save()

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1538,7 +1538,7 @@ class TestScrape(ScrapeTestCase):
 
     def test_empty(self):
         page = ""
-        self.assertScrape(page, [], [('false_start', 0, 0, {})])
+        self.assertScrape(page, [], [])
 
     def test_incomplete_parse_error(self):
         page = "<h2>Incomplete</h2><p>Incomplete</p>"
@@ -2013,14 +2013,13 @@ class TestScrapeFeaturePage(FeaturePageTestCase):
             translation.save()
 
     def test_empty_page(self):
-        self.set_content('')
+        self.set_content('  ')
         scrape_feature_page(self.page)
         fp = FeaturePage.objects.get(id=self.page.id)
-        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertEqual(fp.STATUS_NO_DATA, fp.status)
         self.assertEqual(
-            [['false_start', 0, 0, {}]],
-            fp.data['meta']['scrape']['raw']['issues'])
-        self.assertTrue(fp.has_issues)
+            [], fp.data['meta']['scrape']['raw']['issues'])
+        self.assertFalse(fp.has_issues)
 
     def test_parse_issue(self):
         bad_page = '''\

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1597,7 +1597,7 @@ class FeaturePageTestCase(ScrapeTestCase):
                            'Web/CSS/background-size'),
                     'fr': ('https://developer.mozilla.org/fr/docs/'
                            'Web/CSS/background-size')},
-                'name': {'zxx': 'background-size'},
+                'name': 'background-size',
                 'obsolete': False,
                 'slug': 'web-css-background-size',
                 'stable': True,

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -99,13 +99,11 @@ class TestFetchMetaTask(TestCase):
 
     def test_good_call(self):
         data = {
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        }
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]}
         self.response.json.side_effect = None
         self.response.json.return_value = data
         self.mocked_fetch_all.side_effect = None
@@ -171,13 +169,11 @@ class TestFetchAllTranslationsTask(TestCase):
         meta = self.fp.meta()
         meta.status = meta.STATUS_FETCHED
         meta.raw = dumps({
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        })
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]})
         meta.save()
 
         self.patcher_fetch_trans = mock.patch(
@@ -241,13 +237,11 @@ class TestFetchTranslationTask(TestCase):
         meta = self.fp.meta()
         meta.status = meta.STATUS_FETCHED
         meta.raw = dumps({
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        })
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]})
         meta.save()
         self.fp.translatedcontent_set.create(locale='en-US')
         self.fp.translatedcontent_set.create(locale='es')

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -109,6 +109,14 @@ class TestFeaturePageSearch(TestCase):
         next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
         self.assertRedirects(response, next_url)
 
+    def test_post_found_with_anchor(self):
+        fp = FeaturePage.objects.create(
+            url=self.mdn_url, feature_id=741, data='{"foo": "bar"}')
+        url = self.mdn_url + "#Browser_Compat"
+        response = self.client.get(self.url, {'url': url})
+        next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
+        self.assertRedirects(response, next_url)
+
     def test_not_found_with_perms(self):
         self.login_user(groups=['import-mdn'])
         response = self.client.get(self.url, {'url': self.mdn_url})

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, JsonResponse
+from django.utils.six.moves.urllib.parse import urlparse, urlunparse
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView
@@ -82,8 +83,10 @@ class SearchForm(forms.Form):
 
     def clean_url(self):
         data = self.cleaned_data['url']
-        validate_mdn_url(data)
-        return data
+        scheme, netloc, path, params, query, fragment = urlparse(data)
+        cleaned = urlunparse((scheme, netloc, path, '', '', ''))
+        validate_mdn_url(cleaned)
+        return cleaned
 
 
 class FeaturePageSearch(TemplateResponseMixin, View, FormMixin):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,17 +2,18 @@
 
 # Documentation
 Pygments==2.0.2
-sphinx-rtd-theme==0.1.7
-alabaster==0.7.3
+sphinx-rtd-theme==0.1.8
+alabaster==0.7.4
 Babel==1.3
 snowballstemmer==1.2.0
 Sphinx==1.3.1
 docutils==0.12
 
 # Multi-environment testing
-py==1.4.26
+py==1.4.27
+pluggy==0.3.0
 virtualenv==12.1.1
-tox==1.9.2
+tox==2.0.1
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3
@@ -26,7 +27,7 @@ flake8-docstrings==0.2.1.post1
 check-manifest==0.24
 
 # Package QA
-pyroma==1.7
+pyroma==1.8.1
 
 # For ./manage.py runserver_plus
 Werkzeug==0.10.4
@@ -37,7 +38,7 @@ ipython==3.1.0
 ipdb==0.8
 
 # Debugging
-sqlparse==0.1.14
+sqlparse==0.1.15
 django-debug-toolbar==1.3.0
 
 # Test coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,34 +2,34 @@
 
 # Django
 # 1.8 is waiting on django-simple-history
-Django==1.7.7  # rq.filter: >=1.7, <1.8
+Django==1.7.8  # rq.filter: >=1.7, <1.8
 
 # Better templates
 MarkupSafe==0.23
 Jinja2==2.7.3
-jingo==0.7
+jingo==0.7.1
 
 # Django REST Framework.
-djangorestframework==3.1.1
-Markdown==2.6.1
-django-filter==0.9.2
+djangorestframework==3.1.2
+Markdown==2.6.2
+django-filter==0.10.0
 
 # Django extensions
 six==1.9.0
-django-extensions==1.5.2
+django-extensions==1.5.5
 
 # JSON API interfaces for Django REST Framework
 git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api
 
 # History of changes to models
-django-simple-history==1.5.4
+django-simple-history==1.6.1
 
 # Configure database from env
 dj-database-url==0.3.0
 
 # Better test runner (included in settings)
 nose==1.3.6
-django-nose==1.3
+django-nose==1.4
 
 # Test Mocking, included in Python 3.3
 mock==1.0.1
@@ -41,26 +41,27 @@ gunicorn==19.3.0
 psycopg2==2.6
 
 # Serve static files
-static3==0.5.1
+# static3 0.6.0 has utf-8 issue
+git+git://github.com/ryanhiebert/static3@tox-fix#egg=static3
 dj-static==0.0.6
 
 # Timezone info
-pytz==2015.2
+pytz==2015.4
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
-pylibmc==1.4.1
+pylibmc==1.4.2
 django-pylibmc==0.6.0
 django-pylibmc-sasl==0.2.4
 
 # Celery - async task management
-billiard==3.3.0.19
+billiard==3.3.0.20
 amqp==1.4.6
 anyjson==0.3.3
-kombu==3.0.24
-celery==3.1.17
+kombu==3.0.26
+celery==3.1.18
 
 # Modified Preorder Tree Traversal
-django-mptt==0.7.1
+django-mptt==0.7.3
 
 # Sorted ManyToManyField
 django-sortedm2m==0.9.5
@@ -80,7 +81,7 @@ git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app
 # python3-openid >= 3.0.1 # Python 3.x - unused by app
-requests==2.6.0
+requests==2.7.0
 oauthlib==0.7.2
-requests-oauthlib==0.4.2
+requests-oauthlib==0.5.0
 django-allauth==0.19.1

--- a/tools/client.py
+++ b/tools/client.py
@@ -218,55 +218,16 @@ class Client(object):
 
 if __name__ == "__main__":
     from math import log10, trunc
-    import argparse
-    import sys
+    from common import ToolParser
 
-    description = 'Demo client with resource count'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '--all-data', action="store_true",
-        help='Import all the data, rather than a subset')
+    parser = ToolParser(
+        description='Demo client with resource count', include=['api'],
+        logger=logger)
+
     args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
     api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
     logger.info("Counting resources on %s" % api)
 
-    # Get counts
     client = Client(api)
     resources = [
         'browsers', 'versions', 'features', 'supports', 'specifications',

--- a/tools/common.py
+++ b/tools/common.py
@@ -1,0 +1,275 @@
+"""Common tool code."""
+from __future__ import print_function
+
+import argparse
+import codecs
+import getpass
+import logging
+import os.path
+import string
+import sys
+
+import requests
+
+from client import Client
+from resources import CollectionChangeset
+
+_my_dir = os.path.dirname(os.path.realpath(__file__))
+_data_dir = os.path.realpath(os.path.join(_my_dir, '..', 'data'))
+
+try:
+    input = raw_input  # Get the Py2 raw_input
+except NameError:
+    pass  # We're in Py3
+
+
+class ToolParser(argparse.ArgumentParser):
+    """Parser with common options."""
+
+    class StripTrailingSlash(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if values.endswith('/'):
+                values = values[:-1]
+            setattr(namespace, self.dest, values)
+
+    def __init__(
+            self, logger=None, include=None, *args, **kwargs):
+        """Initialize the parser.
+
+        Same as ArgumentParser, but with additional options:
+        logger - Initialize the logger with -v/-q options
+        include - list of additional options to include.  Supported:
+            api - Add --api option
+            user - Add --user option
+            password - Add --password option
+            data - Add --data option
+        """
+        super(ToolParser, self).__init__(*args, **kwargs)
+
+        self.include_set = set(include or [])
+        valid = set(['api', 'user', 'password', 'data'])
+        if self.include_set - valid:
+            raise ValueError(
+                'Unknown include items: {}'.format(self.include_set - valid))
+
+        if 'api' in self.include_set:
+            self.add_argument(
+                '-a', '--api',
+                help='Base URL of the API (default: http://localhost:8000)',
+                default="http://localhost:8000",
+                action=ToolParser.StripTrailingSlash)
+
+        if 'user' in self.include_set:
+            self.add_argument(
+                '-u', '--user',
+                help='Username on API (default: prompt for username)')
+
+        if 'password' in self.include_set:
+            self.add_argument(
+                '-p', '--password',
+                help='Password on API (default: prompt for password)')
+
+        if logger:
+            self.logger = logger
+            self.add_argument(
+                '-v', '--verbose', action="store_true",
+                help='Print extra debug information')
+            self.add_argument(
+                '-q', '--quiet', action="store_true",
+                help='Only print warnings')
+
+        if 'data' in self.include_set:
+            self.add_argument(
+                '-d', '--data', default=_data_dir,
+                action=ToolParser.StripTrailingSlash,
+                help='Output data folder (default: %s)' % _data_dir)
+
+    def parse_args(self, *args, **kwargs):
+        args = super(ToolParser, self).parse_args(*args, **kwargs)
+
+        # Setup logger w/ options
+        if self.logger:
+            verbose = args.verbose
+            quiet = args.quiet
+            console = logging.StreamHandler(sys.stderr)
+            formatter = logging.Formatter('%(levelname)s - %(message)s')
+            fmat = '%(levelname)s - %(message)s'
+            logger_name = 'tools'
+            if quiet:
+                level = logging.WARNING
+            elif verbose:
+                level = logging.DEBUG
+                logger_name = ''
+                fmat = '%(name)s - %(levelname)s - %(message)s'
+            else:
+                level = logging.INFO
+            formatter = logging.Formatter(fmat)
+            console.setLevel(level)
+            console.setFormatter(formatter)
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(level)
+            logger.addHandler(console)
+
+        return args
+
+
+class Tool(object):
+    """A tool for working with the API."""
+    logger_name = 'tools'
+    parser_options = []
+
+    def __init__(self):
+        """Initialize the tool."""
+        self.api = None
+        self._client = None
+        self.logger = logging.getLogger(self.logger_name)
+        self.data = 'data'
+
+    def cached_download(self, filename, url):
+        """Download a file, then serve it from the cache."""
+        path = self.data_file(filename)
+        if not os.path.exists(path):
+            self.logger.info("Downloading " + path)
+            r = requests.get(url)
+            with codecs.open(path, 'wb', 'utf8') as f:
+                f.write(r.text)
+        else:
+            self.logger.info("Using existing " + path)
+
+        with codecs.open(path, 'r', 'utf8') as f:
+            content = f.read()
+        return content
+
+    @property
+    def client(self):
+        """Return an API Client."""
+        assert self.api, 'Must set API first'
+        if not self._client:
+            self._client = Client(self.api)
+        return self._client
+
+    def confirm_changes(self, changeset):
+        """Ask the user to confirm a changeset."""
+        while True:
+            choice = input("Make these changes? (Y/N/D for details) ")
+            if choice.upper() == 'Y':
+                return True
+            elif choice.upper() == 'N':
+                return False
+            elif choice.upper() == 'D':
+                print(changeset.summarize())
+            else:
+                print("Please type Y or N or D.")
+
+    def data_file(self, filename):
+        """Return the path to a data file."""
+        return os.path.join(self.data, filename)
+
+    def get_parser(self):
+        """Construct the command line parser."""
+        description = self.__doc__.split('\n')[0]
+        parser = ToolParser(
+            description=description, logger=self.logger,
+            include=self.parser_options)
+        return parser
+
+    def get_password(self):
+        """Get the password, prompting if needed."""
+        if not getattr(self, 'password'):
+            self.password = getpass.getpass("API password: ")
+        return self.password
+
+    def get_user(self):
+        """Get the user, prompting if needed."""
+        if not getattr(self, 'user'):
+            self.user = input("API username: ")
+        return self.user
+
+    def init_from_command_line(self):
+        """Initialize the tool from the command line."""
+        parser = self.get_parser()
+        args = parser.parse_args()
+        for key, value in vars(args).items():
+            setattr(self, key, value)
+        return args
+
+    def login(self):
+        user = self.get_user()
+        password = self.get_password()
+        self.client.login(user, password)
+
+    def report_changes(self, counts):
+        if counts:
+            self.logger.info("Changes complete. Counts:")
+            for resource_type, changes in counts.items():
+                c_new = changes.get('new', 0)
+                c_deleted = changes.get('deleted', 0)
+                c_changed = changes.get('changed', 0)
+                c_text = []
+                if c_new:
+                    c_text.append("%d new" % c_new)
+                if c_deleted:
+                    c_text.append("%d deleted" % c_deleted)
+                if c_changed:
+                    c_text.append("%d changed" % c_changed)
+                if c_text:
+                    self.logger.info("  %s: %s" % (
+                        resource_type.title(), ', '.join(c_text)))
+        else:
+            self.logger.info("No data uploaded.")
+
+    def run(self, *args, **kwargs):
+        """Run the tool."""
+        raise NotImplementedError('run not implemented')
+
+    def slugify(self, word, attempt=0):
+        """Slugify a word, mixing in an attempt count as needed."""
+        raw = word.lower().encode('utf-8')
+        out = []
+        acceptable = string.ascii_lowercase + string.digits + '_-'
+        for c in raw:
+            if c in acceptable:
+                out += str(c)
+            else:
+                out += '_'
+        slugged = ''.join(out)
+        while '__' in slugged:
+            slugged = slugged.replace('__', '_')
+        if attempt:
+            suffix = str(attempt)
+        else:
+            suffix = ""
+        return slugged[slice(50 - len(suffix))] + suffix
+
+    def sync_changes(self, api_collection, local_collection):
+        """Sync changes to a remote collection from a local collection
+
+        Returns a dictionary counting the new, changed, and deleted items,
+        or an empty dictionary if no changes.
+        """
+        self.logger.info('Looking for changes...')
+        changeset = CollectionChangeset(api_collection, local_collection)
+        delta = changeset.changes
+
+        if delta['new'] or delta['changed'] or delta['deleted']:
+            self.logger.info(
+                'Changes detected: %d new, %d changed, %d deleted, %d same.',
+                len(delta['new']), len(delta['changed']),
+                len(delta['deleted']), len(delta['same']))
+            confirmed = self.confirm_changes(changeset)
+            if not confirmed:
+                return {}
+        else:
+            self.logger.info('No changes')
+            return {}
+
+        return changeset.change_original_collection()
+
+    def unique_slugify(self, word, existing):
+        slug = self.slugify(word)
+        attempt = 0
+        while slug in existing:
+            attempt += 1
+            slug = self.slugify(word, attempt)
+        existing.add(slug)
+        return slug

--- a/tools/download_data.py
+++ b/tools/download_data.py
@@ -1,109 +1,49 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 import codecs
 import json
-import logging
-import os.path
-import sys
 
-from client import Client
-
-logger = logging.getLogger('tools.download_data')
-
-resources = [
-    'browsers',
-    'versions',
-    'features',
-    'supports',
-    'specifications',
-    'maturities',
-    'sections',
-]
+from common import Tool
 
 
-def download_data(client, base_dir=''):
-    """Download data from the API"""
-    counts = {}
-    for resource in resources:
-        # Get data from API
-        data = client.get_resource_collection(resource)
-        logger.info("Downloaded %d %s.", len(data[resource]), resource)
-        counts[resource] = len(data[resource])
+class DownloadData(Tool):
+    """Download data from the API."""
+    logger_name = 'tools.download_data'
+    parser_options = ['api', 'data']
 
-        # Remove history relations
-        for item in data[resource]:
-            del item['links']['history']
-            del item['links']['history_current']
-        if 'links' in data:
-            del data['links']['%s.history' % resource]
-            del data['links']['%s.history_current' % resource]
+    def run(self, *args, **kwargs):
+        counts = {}
+        resources = [
+            'browsers', 'versions', 'features', 'supports', 'specifications',
+            'maturities', 'sections']
+        for resource in resources:
+            # Get data from API
+            data = self.client.get_resource_collection(resource)
+            self.logger.info(
+                "Downloaded {} {}".format(len(data[resource]), resource))
+            counts[resource] = len(data[resource])
 
-        # Write to a file
-        filepath = os.path.join(base_dir, '%s.json' % resource)
-        with codecs.open(filepath, 'w', 'utf8') as f:
-            json.dump(data, f, indent=4, separators=(',', ': '))
+            # Remove history relations
+            for item in data[resource]:
+                del item['links']['history']
+                del item['links']['history_current']
+            if 'links' in data:
+                del data['links'][resource + '.history']
+                del data['links'][resource + '.history_current']
 
-    return counts
+            # Write to a file
+            filepath = self.data_file('{}.json'.format(resource))
+            with codecs.open(filepath, 'w', 'utf8') as f:
+                json.dump(data, f, indent=4, separators=(',', ': '))
+        return counts
+
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Download data from API.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '-d', '--data', default='data',
-        help='Output data folder (default: data)')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    fmat = '%(levelname)s - %(message)s'
-    logger_name = 'tools'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    data = args.data
-    if data.endswith('/'):
-        data = data[:-1]
-    logger.info("Downloading data from %s to %s", api, data)
-
-    # Initialize client
-    client = Client(api)
-
-    # Load data
-    counts = download_data(client, data)
-
+    tool = DownloadData()
+    tool.init_from_command_line()
+    tool.logger.info(
+        "Downloading data from {tool.api} to {tool.data}".format(tool=tool))
+    counts = tool.run()
     if counts:
-        logger.info("Download complete.")
+        tool.logger.info("Download complete.")
     else:
-        logger.info("No data downloaded.")
+        tool.logger.info("No data downloaded.")

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -6,19 +6,10 @@ from collections import Counter
 from json import dumps
 from HTMLParser import HTMLParser
 import csv
-import logging
-import os.path
 import re
-import sys
 import time
 
-from client import Client
-
-logger = logging.getLogger('tools.gather_import_issues')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_issues_by_url.csv')
-BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_issue_counts.csv')
+from common import Tool
 
 
 class GatherLinks(HTMLParser):
@@ -40,138 +31,107 @@ class GatherLinks(HTMLParser):
         return ["/importer/%d.json" % i for i in sorted(self.import_ids)]
 
 
-def gather_import_issues(client, by_url_csv, by_issue_csv):
-    issue_rows = download_issues(client)
-    issue_counts = Counter()
+class GatherImportIssues(Tool):
+    """Gather import issues into CSVs."""
+    logger_name = 'tools.gather_import_issues'
+    parser_options = ['api', 'data']
 
-    # Write by-url CSV and count issues
-    by_url_writer = csv.writer(by_url_csv)
-    by_url_writer.writerow(
-        ["MDN Slug", "Import URL", "Issue Slug", "Source Start", "Source End",
-         "Params"])
-    for row in issue_rows:
-        err = row[4]
-        issue_counts[err] += 1
-        by_url_writer.writerow(row)
+    def run(self, by_url_csv, by_issue_csv, *args, **kwargs):
+        issue_rows = self.download_issues()
+        issue_counts = Counter()
 
-    # Write by_issue CSV
-    by_issue_writer = csv.writer(by_issue_csv)
-    by_issue_writer.writerow(["Count", "Issue"])
-    for err, count in issue_counts.most_common():
-        by_issue_writer.writerow((count, err))
+        # Write by-url CSV and count issues
+        by_url_writer = csv.writer(by_url_csv)
+        by_url_writer.writerow([
+            "MDN Slug", "Import URL", "Issue Slug", "Source Start",
+            "Source End", "Params"])
+        for row in issue_rows:
+            err = row[4]
+            issue_counts[err] += 1
+            by_url_writer.writerow(row)
 
-    return {
-        'total': len(issue_rows),
-        'unique': len(issue_counts),
-    }
+        # Write by_issue CSV
+        by_issue_writer = csv.writer(by_issue_csv)
+        by_issue_writer.writerow(["Count", "Issue"])
+        for err, count in issue_counts.most_common():
+            by_issue_writer.writerow((count, err))
 
+        return {
+            'total': len(issue_rows),
+            'unique': len(issue_counts),
+        }
 
-def download_issues(client):
-    # Gather import links
-    start = time.time()
-    logger.info("Gathering import URLs from %s...", client.base_url)
-    page = 1
-    parser = GatherLinks()
-    status = 200
-    while status == 200:
-        index_url = client.base_url + '/importer/'
-        index_resp = client.session.get(index_url, params={'page': page})
-        status = index_resp.status_code
-        if status == 200:
-            parser.feed(index_resp.text)
-            page += 1
-    import_urls = parser.get_urls()
-    total_urls = len(import_urls)
-    end = time.time()
-    logger.info("Found %d import URLs in %0.1fs", total_urls, end - start)
+    def download_issues(self):
+        """Download issues from API."""
+        assert self.api, 'Must set api to API base URL'
 
-    # Gather issues
-    issue_rows = []
-    start = time.time()
-    for url_count, raw_url in enumerate(import_urls):
-        url = client.base_url + raw_url
-        human_import_url = url.replace('.json', '')
-        resp = client.session.get(url)
-        resp.raise_for_status()
-        resp_json = resp.json()
-        mdn_uri = resp_json['features']['mdn_uri']['en']
-        mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
-        assert mdn_uri.startswith(mdn_prefix)
-        mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
-        issues = resp_json['meta']['scrape']['issues']
-        for issue in issues:
-            assert isinstance(issue, list)
-            issue_slug, start_pos, end_pos, raw_params = issue
-            params = dumps(raw_params)
-            issue_rows.append(
-                (mdn_slug, human_import_url, issue_slug, start_pos, end_pos,
-                 params))
+        # Gather import links
+        start = time.time()
+        self.logger.info("Gathering import URLs from %s...", self.api)
+        page = 1
+        parser = GatherLinks()
+        status = 200
+        while status == 200:
+            index_url = self.api + '/importer/'
+            index_resp = self.client.session.get(
+                index_url, params={'page': page})
+            status = index_resp.status_code
+            if status == 200:
+                parser.feed(index_resp.text)
+                page += 1
+        import_urls = parser.get_urls()
+        total_urls = len(import_urls)
         end = time.time()
-        if (end - start) > 15:
-            percent = 100.0 * (1 - (total_urls - url_count + 1.0) / total_urls)
-            logger.info(
-                "Found %d issues in %d imports (%d%%)",
-                len(issue_rows), url_count + 1, percent)
-            start = time.time()
+        self.logger.info(
+            "Found %d import URLs in %0.1fs", total_urls, end - start)
 
-    return issue_rows
+        # Gather issues
+        issue_rows = []
+        start = time.time()
+        for url_count, raw_url in enumerate(import_urls):
+            url = self.api + raw_url
+            human_import_url = url.replace('.json', '')
+            resp = self.client.session.get(url)
+            resp.raise_for_status()
+            resp_json = resp.json()
+            mdn_uri = resp_json['features']['mdn_uri']['en']
+            mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
+            assert mdn_uri.startswith(mdn_prefix)
+            mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
+            issues = resp_json['meta']['scrape']['issues']
+            for issue in issues:
+                assert isinstance(issue, list)
+                issue_slug, start_pos, end_pos, raw_params = issue
+                params = dumps(raw_params)
+                issue_rows.append(
+                    (mdn_slug, human_import_url, issue_slug, start_pos,
+                     end_pos, params))
+            end = time.time()
+            if (end - start) > 15:
+                percent = (
+                    100.0 * (1 - (total_urls - url_count + 1.0) / total_urls))
+                self.logger.info(
+                    "Found %d issues in %d imports (%d%%)",
+                    len(issue_rows), url_count + 1, percent)
+                start = time.time()
+
+        return issue_rows
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Gather import issues into CSVs.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
+    tool = GatherImportIssues()
+    tool.init_from_command_line()
+    tool.logger.info("Loading import issues from {tool.api}".format(tool=tool))
 
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading importer issues from %s" % api)
-
-    # Initialize client
-    client = Client(api)
-
-    # Gather issues and write to CSVs
     counts = {}
     by_url_csv = None
     by_issue_csv = None
+    by_url_file = tool.data_file('import_issues_by_url.csv')
+    by_issue_file = tool.data_file('import_issue_counts.csv')
     try:
-        by_url_csv = open(BY_URL_CSV_FILENAME, "wb")
-        by_issue_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
-        counts = gather_import_issues(client, by_url_csv, by_issue_csv)
+        by_url_csv = open(by_url_file, "wb")
+        by_issue_csv = open(by_issue_file, "wb")
+        counts = tool.run(by_url_csv, by_issue_csv)
     finally:
         if by_issue_csv:
             by_issue_csv.close()
@@ -181,9 +141,9 @@ if __name__ == '__main__':
     if counts:
         c_unique = counts.get('unique', 0)
         c_total = counts.get('total', 0)
-        logger.info(
+        tool.logger.info(
             "Issues collected: %d unique (%d total)", c_unique, c_total)
-        logger.info("Issue details in %s", BY_URL_CSV_FILENAME)
-        logger.info("Issue counts in %s", BY_ERRORS_CSV_FILENAME)
+        tool.logger.info("Issue details in %s", by_url_file)
+        tool.logger.info("Issue counts in %s", by_issue_file)
     else:
-        logger.info("No issues found.")
+        tool.logger.info("No issues found.")

--- a/tools/import_mdn.py
+++ b/tools/import_mdn.py
@@ -1,157 +1,96 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
-import getpass
-import logging
-import os.path
-import sys
 import time
 
-from client import Client
+from common import Tool
 from resources import Collection
 
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
 
-logger = logging.getLogger('tools.import_mdn')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+class ImportMDNData(Tool):
+    """Import features from MDN, or reparse imported features."""
+    logger_name = 'tools.import_mdn'
+    parser_options = ['api', 'user', 'password']
 
+    def run(self, rate=5, *args, **kwargs):
+        self.login()
+        collection = Collection(self.client)
+        collection.load_all('features')
 
-def import_mdn_data(client, rate=5):
-    collection = Collection(client)
-    collection.load_all('features')
+        # Collect feature URIs
+        uris = []
+        for feature in collection.get_resources('features'):
+            if feature.mdn_uri and feature.mdn_uri.get('en'):
+                uris.append((feature.mdn_uri['en'], feature.id.id))
+        total = len(uris)
+        self.logger.info('Features loaded, %d MDN pages found.', total)
 
-    # Collect feature URIs
-    uris = []
-    for feature in collection.get_resources('features'):
-        if feature.mdn_uri and feature.mdn_uri.get('en'):
-            uris.append((feature.mdn_uri['en'], feature.id.id))
-    total = len(uris)
-    logger.info('Features loaded, %d MDN pages found.', total)
+        # Import from MDN, with rate limiting
+        start_time = time.time()
+        mdn_requests = 0
+        counts = {'new': 0, 'reset': 0, 'reparsed': 0, 'unchanged': 0}
+        importer_search = self.api + '/importer/search'
+        log_at = 15
+        logged_at = time.time()
+        for uri, f_id in uris:
+            response = self.client.session.get(
+                importer_search, params={'url': uri})
+            if 'importer/create?' in response.url:
+                self.logger.info('Fetching %s...', uri)
+                counts['new'] += 1
+                create_url = response.url
+                csrf = self.client.session.cookies['csrftoken']
+                params = {
+                    'url': uri,
+                    'feature': f_id,
+                    'csrfmiddlewaretoken': csrf,
+                }
+                response = self.client.session.post(create_url, params)
+                mdn_requests += 1
+            else:
+                response.raise_for_status()
+                obj_url = response.url
+                assert '/importer/' in obj_url
+                reparse_url = obj_url + '/reparse'
+                csrf = self.client.session.cookies['csrftoken']
+                params = {'csrfmiddlewaretoken': csrf}
+                response = self.client.session.post(reparse_url, params)
+                counts['reparsed'] += 1
 
-    # Import from MDN, with rate limiting
-    start_time = time.time()
-    mdn_requests = 0
-    counts = {'new': 0, 'reset': 0, 'reparsed': 0, 'unchanged': 0}
-    importer_search = client.base_url + '/importer/search'
-    log_at = 15
-    logged_at = time.time()
-    for uri, f_id in uris:
-        response = client.session.get(importer_search, params={'url': uri})
-        if 'importer/create?' in response.url:
-            logger.info('Fetching %s...', uri)
-            counts['new'] += 1
-            create_url = response.url
-            csrf = client.session.cookies['csrftoken']
-            params = {
-                'url': uri,
-                'feature': f_id,
-                'csrfmiddlewaretoken': csrf,
-            }
-            response = client.session.post(create_url, params)
-            mdn_requests += 1
-        else:
-            response.raise_for_status()
-            obj_url = response.url
-            assert '/importer/' in obj_url
-            reparse_url = obj_url + '/reparse'
-            csrf = client.session.cookies['csrftoken']
-            params = {'csrfmiddlewaretoken': csrf}
-            response = client.session.post(reparse_url, params)
-            counts['reparsed'] += 1
+            # Pause for rate limiting?
+            current_time = time.time()
+            if rate:
+                elapsed = current_time - start_time
+                target = start_time + float(mdn_requests) / rate
+                current_rate = float(mdn_requests) / elapsed
+                if time.time < target:
+                    rest = int(target - current_time) + 1
+                    self.logger.warning(
+                        "%d pages fetched, %0.2f per second, target rate %d"
+                        " per second.  Resting %d seconds.",
+                        mdn_requests, current_rate, rate, rest)
+                    time.sleep(rest)
+                    logged_at = time.time()
+                    current_time = time.time()
 
-        # Pause for rate limiting?
-        current_time = time.time()
-        if rate:
-            elapsed = current_time - start_time
-            target = start_time + float(mdn_requests) / rate
-            current_rate = float(mdn_requests) / elapsed
-            if time.time < target:
-                rest = int(target - current_time) + 1
-                logger.warning(
-                    "%d pages fetched, %0.2f per second, target rate %d per"
-                    " second.  Resting %d seconds.",
-                    mdn_requests, current_rate, rate, rest)
-                time.sleep(rest)
-                logged_at = time.time()
-                current_time = time.time()
+            # Log progress?
+            if (logged_at + log_at) < current_time:
+                processed = sum(counts.values())
+                percent = int(100 * (float(processed) / total))
+                self.logger.info(
+                    "  Processed %d of %d MDN pages (%d%%)...",
+                    processed, total, percent)
+                logged_at = current_time
 
-        # Log progress?
-        if (logged_at + log_at) < current_time:
-            processed = sum(counts.values())
-            percent = int(100 * (float(processed) / total))
-            logger.info(
-                "  Processed %d of %d MDN pages (%d%%)...",
-                processed, total, percent)
-            logged_at = current_time
-
-    return counts
+        return counts
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Import features from MDN, or reparse imported features.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading data into %s" % api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    counts = import_mdn_data(client)
+    tool = ImportMDNData()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}".format(tool=tool))
+    counts = tool.run()
 
     if counts:
-        logger.info("Import complete. Counts:")
+        tool.logger.info("Import complete. Counts:")
         c_new = counts.get('new', 0)
         c_reset = counts.get('reset', 0)
         c_reparsed = counts.get('reparsed', 0)
@@ -166,6 +105,6 @@ if __name__ == '__main__':
         if c_unchanged:
             c_text.append("%d unchanged" % c_unchanged)
         if c_text:
-            logger.info(', '.join(c_text))
+            tool.logger.info(', '.join(c_text))
     else:
-        logger.info("No data uploaded.")
+        tool.logger.info("No data uploaded.")

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -1,347 +1,185 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
-import codecs
-import getpass
-import logging
-import os.path
 import re
-import string
-import sys
 
-import requests
-
-from client import Client
-from resources import Collection, CollectionChangeset, Maturity, Specification
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
-
-logger = logging.getLogger('tools.load_spec_data')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-SPEC2_FILENAME = os.path.join(data_dir, 'Spec2.txt')
-SPEC2_URL = 'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw'
-SPECNAME_FILENAME = os.path.join(data_dir, 'SpecName.txt')
-SPECNAME_URL = 'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw'
+from common import Tool
+from resources import Collection, Maturity, Specification
 
 
-def get_template(filename, url):
-    if not os.path.exists(filename):
-        logger.info("Downloading " + filename)
-        r = requests.get(url)
-        with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.text)
-    else:
-        logger.info("Using existing " + filename)
+class LoadSpecData(Tool):
+    """Initialize API with specification data from MDN."""
+    logger_name = 'tools.load_spec_data'
+    parser_options = ['api', 'user', 'password']
 
-    with codecs.open(filename, 'r', 'utf8') as f:
-        template = f.read()
-    return template
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        local_collection = Collection()
 
+        self.logger.info('Reading existing spec data from API')
+        api_collection.load_all('maturities')
+        api_collection.load_all('specifications')
 
-def load_spec_data(client, specname, spec2, confirm=None):
-    """Load a dictionary of specification data into the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+        self.logger.info('Reading spec data from MDN templates')
+        specname = self.specname_template()
+        self.parse_specname(specname, api_collection, local_collection)
+        spec2 = self.spec2_template()
+        self.parse_spec2(spec2, local_collection)
 
-    logger.info('Reading existing spec data from API')
-    load_api_spec_data(api_collection)
-    logger.info('Reading spec data from MDN templates')
-    parse_spec_data(specname, spec2, api_collection, local_collection)
+        # Load API sections into local collection
+        local_collection.override_ids_to_match(api_collection)
+        local_specs = local_collection.get_resources('specifications')
+        for local_spec in local_specs:
+            api_spec = api_collection.get('specifications', local_spec.id.id)
+            if api_spec:
+                local_spec.sections = api_spec.sections.ids
+        return self.sync_changes(api_collection, local_collection)
 
-    # Load API sections into local collection
-    local_collection.override_ids_to_match(api_collection)
-    local_specs = local_collection.get_resources('specifications')
-    for local_spec in local_specs:
-        api_spec = api_collection.get('specifications', local_spec.id.id)
-        if api_spec:
-            local_spec.sections = api_spec.sections.ids
+    def specname_template(self):
+        return self.cached_download(
+            'SpecName.txt',
+            'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw')
 
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
+    def spec2_template(self):
+        return self.cached_download(
+            'Spec2.txt',
+            'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw')
 
-    counts = changeset.change_original_collection()
-    return counts
+    def parse_specname(self, specname, api_collection, local_collection):
+        phase = 0
+        mdn_key = None
+        name = None
+        url = None
+        slugs = set([
+            s.slug for s in api_collection.get_resources('specifications')])
+        mdn_key_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*{")
+        name_re = re.compile(r"\s+name\s*:\s*['\"](.*)['\"],?\s*$")
+        url_re = re.compile(r"\s+url\s*:\s*['\"](.*)['\"],?\s*$")
+        api_specs = api_collection.get_resources_by_data_id('specifications')
 
-
-def load_api_spec_data(api_collection):
-    api_collection.load_all('maturities')
-    api_collection.load_all('specifications')
-
-
-def parse_spec_data(specname, spec2, api_collection, local_collection):
-    parse_specname(specname, api_collection, local_collection)
-    parse_spec2(spec2, local_collection)
-
-
-def parse_specname(specname, api_collection, local_collection):
-    phase = 0
-    mdn_key = None
-    name = None
-    url = None
-    slugs = set([
-        s.slug for s in api_collection.get_resources('specifications')])
-    mdn_key_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*{")
-    name_re = re.compile(r"\s+name\s*:\s*['\"](.*)['\"],?\s*$")
-    url_re = re.compile(r"\s+url\s*:\s*['\"](.*)['\"],?\s*$")
-    api_specs = api_collection.get_resources_by_data_id('specifications')
-
-    for line in specname.split('\n'):
-        if phase == 0:
-            # Looking for start of specList
-            if line.startswith('var specList = {'):
-                phase = 1
-        elif phase == 1:
-            # Inside specList
-            if line.startswith('}'):
-                phase = 2
-            elif mdn_key_re.match(line):
-                assert mdn_key is None
-                mdn_key = mdn_key_re.match(line).group(1).strip()
-            elif name_re.match(line):
-                assert name is None
-                name = name_re.match(line).group(1).strip()
-            elif url_re.match(line):
-                assert url is None
-                url = url_re.match(line).group(1).strip()
-            elif line.startswith('    }'):
-                assert mdn_key is not None
-                assert name is not None
-                assert url is not None
-                if url.startswith('http'):
-                    api_spec = api_specs.get(('specifications', mdn_key))
-                    if api_spec:
-                        slug = api_spec.slug
+        for line in specname.split('\n'):
+            if phase == 0:
+                # Looking for start of specList
+                if line.startswith('var specList = {'):
+                    phase = 1
+            elif phase == 1:
+                # Inside specList
+                if line.startswith('}'):
+                    phase = 2
+                elif mdn_key_re.match(line):
+                    assert mdn_key is None
+                    mdn_key = mdn_key_re.match(line).group(1).strip()
+                elif name_re.match(line):
+                    assert name is None
+                    name = name_re.match(line).group(1).strip()
+                elif url_re.match(line):
+                    assert url is None
+                    url = url_re.match(line).group(1).strip()
+                elif line.startswith('    }'):
+                    assert mdn_key is not None
+                    assert name is not None
+                    assert url is not None
+                    if url.startswith('http'):
+                        api_spec = api_specs.get(('specifications', mdn_key))
+                        if api_spec:
+                            slug = api_spec.slug
+                        else:
+                            slug = self.unique_slugify(mdn_key, slugs)
+                        spec = Specification(
+                            id="_" + slug, slug=slug, mdn_key=mdn_key,
+                            name={u'en': name}, uri={u'en': url}, sections=[])
+                        local_collection.add(spec)
                     else:
-                        slug = unique_slugify(mdn_key, slugs)
-                    spec = Specification(
-                        id="_" + slug, slug=slug, mdn_key=mdn_key,
-                        name={u'en': name}, uri={u'en': url}, sections=[])
-                    local_collection.add(spec)
+                        self.logger.warning(
+                            'Discarding specification "%s" with url "%s"',
+                            mdn_key, url)
+                    mdn_key = None
+                    name = None
+                    url = None
                 else:
-                    logger.warning(
-                        'Discarding specification "%s" with url "%s"',
-                        mdn_key, url)
-                mdn_key = None
-                name = None
-                url = None
-            else:
-                raise Exception('Unparsed line:', line)
-        elif phase == 2:
-            # Not processing rest of SpecName, including dupe lines
-            pass
-    assert phase == 2, "SpecName didn't match expected format"
+                    raise Exception('Unparsed line:', line)
+            elif phase == 2:
+                # Not processing rest of SpecName, including dupe lines
+                pass
+        assert phase == 2, "SpecName didn't match expected format"
 
+    def parse_spec2(self, spec2, collection):
+        phase = 0
+        key = None
+        name = None
+        status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
+        mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
+        name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
+        local_specs = collection.get_resources_by_data_id('specifications')
 
-def parse_spec2(specname, local_collection):
-    phase = 0
-    key = None
-    name = None
-    status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
-    mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
-    name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
-    local_specs = local_collection.get_resources_by_data_id('specifications')
-
-    for line in spec2.split('\n'):
-        if phase == 0:
-            # Looking for start of status
-            if line.startswith('var status = {'):
-                phase = 1
-        elif phase == 1:
-            # Inside status
-            if line.startswith('}'):
-                phase = 2
-            elif status_re.match(line):
-                spec_key, maturity_key = status_re.match(line).groups()
-                spec = local_specs.get(('specifications', spec_key))
-                if spec:
-                    spec.maturity = maturity_key
+        for line in spec2.split('\n'):
+            if phase == 0:
+                # Looking for start of status
+                if line.startswith('var status = {'):
+                    phase = 1
+            elif phase == 1:
+                # Inside status
+                if line.startswith('}'):
+                    phase = 2
+                elif status_re.match(line):
+                    spec_key, maturity_key = status_re.match(line).groups()
+                    spec = local_specs.get(('specifications', spec_key))
+                    if spec:
+                        spec.maturity = maturity_key
+                    else:
+                        self.logger.warning(
+                            'Skipping maturity for unknown spec "%s"',
+                            spec_key)
                 else:
-                    logger.warning(
-                        'Skipping maturity for unknown spec "%s"', spec_key)
-            else:
-                raise Exception('Unparsed line:', line)
-        elif phase == 2:
-            # Skiping dupe lines, looking for var label
-            if line.startswith('var label = {'):
-                phase = 3
-        elif phase == 3:
-            if line.startswith('}'):
-                phase = 4
-            elif mat_re.match(line):
-                assert key is None
-                key = mat_re.match(line).group(1).strip()
-                name = {}
-            elif name_re.match(line):
-                assert key is not None
-                assert name is not None
-                lang, trans = name_re.match(line).groups()
-                if lang == 'en-US':
-                    lang = 'en'
-                assert lang not in name
-                text = trans.strip().replace('\\\\', '&#92;')
-                text = text.replace('\\', '').replace('&#92;', '\\')
-                name[lang.strip()] = text
-            elif line.startswith('  })'):
-                assert key is not None
-                assert name
-                specs = local_collection.filter(
-                    'specifications', maturity=key)
-                if specs:
-                    maturity = Maturity(id=key, slug=key, name=name)
-                    local_collection.add(maturity)
-                else:
-                    logger.warning('Skipping unused maturity "%s"', key)
-                key = None
-                name = None
-        elif phase == 4:
-            # Not processing rest of file
-            pass
-    assert phase == 4, "Spec2 didn't match expected format"
+                    raise Exception('Unparsed line:', line)
+            elif phase == 2:
+                # Skiping dupe lines, looking for var label
+                if line.startswith('var label = {'):
+                    phase = 3
+            elif phase == 3:
+                if line.startswith('}'):
+                    phase = 4
+                elif mat_re.match(line):
+                    assert key is None
+                    key = mat_re.match(line).group(1).strip()
+                    name = {}
+                elif name_re.match(line):
+                    assert key is not None
+                    assert name is not None
+                    lang, trans = name_re.match(line).groups()
+                    if lang == 'en-US':
+                        lang = 'en'
+                    assert lang not in name
+                    text = trans.strip().replace('\\\\', '&#92;')
+                    text = text.replace('\\', '').replace('&#92;', '\\')
+                    name[lang.strip()] = text
+                elif line.startswith('  })'):
+                    assert key is not None
+                    assert name
+                    specs = collection.filter('specifications', maturity=key)
+                    if specs:
+                        maturity = Maturity(id=key, slug=key, name=name)
+                        collection.add(maturity)
+                    else:
+                        self.logger.warning(
+                            'Skipping unused maturity "%s"', key)
+                    key = None
+                    name = None
+            elif phase == 4:
+                # Not processing rest of file
+                pass
+        assert phase == 4, "Spec2 didn't match expected format"
 
-    # Remove Specs without maturities
-    immature_specs = local_collection.filter('specifications', maturity=None)
-    for spec in immature_specs:
-        logger.warning('Skipping spec with no maturity "%s"', spec.name['en'])
-        local_collection.remove(spec)
-
-
-def slugify(word, attempt=0):
-    # TODO: replace with mdn.scrape.slugify
-    raw = word.lower().encode('utf-8')
-    out = []
-    acceptable = string.ascii_lowercase + string.digits + '_-'
-    for c in raw:
-        if c in acceptable:
-            out += str(c)
-        else:
-            out += '_'
-    slugged = ''.join(out)
-    while '__' in slugged:
-        slugged = slugged.replace('__', '_')
-    if attempt:
-        suffix = str(attempt)
-    else:
-        suffix = ""
-    return slugged[slice(50 - len(suffix))] + suffix
-
-
-def unique_slugify(word, existing):
-    slug = slugify(word)
-    attempt = 0
-    while slug in existing:
-        attempt += 1
-        slug = slugify(word, attempt)
-    existing.add(slug)
-    return slug
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
-            return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
-        else:
-            print("Please type Y or N or D.")
+        # Remove Specs without maturities
+        immature_specs = collection.filter('specifications', maturity=None)
+        for spec in immature_specs:
+            self.logger.warning(
+                'Skipping spec with no maturity "%s"', spec.name['en'])
+            collection.remove(spec)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Initialize with specification data from MDN.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading data into %s" % api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    specname = get_template(SPECNAME_FILENAME, SPECNAME_URL)
-    spec2 = get_template(SPEC2_FILENAME, SPEC2_URL)
-    counts = load_spec_data(client, specname, spec2, confirm_changes)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    tool = LoadSpecData()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}".format(tool=tool))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -1,162 +1,66 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 from cgi import escape
 from collections import defaultdict
-import codecs
-import getpass
-import json
-import logging
-import os.path
+from json import loads
 import re
-import string
-import sys
 
-import requests
-
-from client import Client
-from resources import (
-    Collection, CollectionChangeset, Browser, Version, Feature, Support)
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
+from common import Tool
+from resources import Collection, Browser, Version, Feature, Support
 
 
-logger = logging.getLogger('tools.load_webcompat_data')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-COMPAT_DATA_FILENAME = os.path.join(data_dir, "data-human.json")
-COMPAT_DATA_URL = (
-    "https://raw.githubusercontent.com/webplatform/compatibility-data"
-    "/master/data-human.json")
-known_browsers = [
-    "Chrome",
-    "Firefox",
-    "Internet Explorer",
-    "Opera",
-    "Safari",
-    "Android",
-    "Chrome for Android",
-    "Chrome Mobile",
-    "Firefox Mobile",
-    "IE Mobile",
-    "Opera Mini",
-    "Opera Mobile",
-    "Safari Mobile",
-    "BlackBerry",
-    "Firefox OS",
-]
-version_re = re.compile("^[.\d]+$")
+class LoadWebcompatData(Tool):
+    """Initialize with data from the webcompat project."""
+    logger_name = 'tools.load_webcompat_data'
+    parser_options = ['api', 'user', 'password']
 
+    def run(self, *args, **kwargs):
+        self.login()
 
-def get_compat_data(filename, url):
-    if not os.path.exists(filename):
-        logger.info("Downloading " + filename)
-        r = requests.get(url)
-        with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.text)
-    else:
-        logger.info("Using existing " + filename)
+        api_collection = Collection(self.client)
+        local_collection = Collection()
+        compat_data = loads(self.cached_download(
+            "data-human.json",
+            "https://raw.githubusercontent.com/webplatform/compatibility-data"
+            "/master/data-human.json"))
 
-    with codecs.open(filename, 'r', 'utf8') as f:
-        compat_data = json.load(f)
-    return compat_data
+        self.logger.info('Reading existing feature data from API')
+        for resource in ['browsers', 'versions', 'features', 'supports']:
+            api_collection.load_all(resource)
+        self.logger.info('Loading feature data from webplatform repository')
+        self.parse_compat_data(compat_data, local_collection)
 
+        if not self.all_data:
+            self.logger.info('Selecting subset of data')
+            self.select_subset(local_collection)
 
-def load_compat_data(client, compat_data, all_data=False, confirm=None):
-    """Load a dictionary of compatibility data into the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+        return self.sync_changes(api_collection, local_collection)
 
-    logger.info('Reading existing feature data from API')
-    load_api_feature_data(api_collection)
-    logger.info('Loading feature data from webplatform repository')
-    parse_compat_data(compat_data, local_collection)
+    def get_parser(self):
+        parser = super(LoadWebcompatData, self).get_parser()
+        parser.add_argument(
+            '--all-data', action="store_true",
+            help='Import all the data, rather than a subset')
+        return parser
 
-    if not all_data:
-        logger.info('Selecting subset of data')
-        select_subset(local_collection)
+    def parse_compat_data(self, compat_data, local_collection):
+        local_collection.feature_slugs = set()
+        for key, value in compat_data['data'].items():
+            self.parse_compat_data_item(key, value, local_collection)
 
-    logger.info('Looking for changes...')
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
+        # Populate the sorted versions
+        browser_versions = defaultdict(list)
+        for version in local_collection.get_resources_by_data_id(
+                'versions').values():
+            browser_versions[version.browser.id].append(version)
+        for browser_id, versions in browser_versions.items():
+            browser = local_collection.get('browsers', browser_id)
+            browser.versions = sorted([v.id.id for v in versions])
 
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
-
-    counts = changeset.change_original_collection()
-    return counts
-
-
-def load_api_feature_data(api_collection):
-    api_collection.load_all('browsers')
-    api_collection.load_all('versions')
-    api_collection.load_all('features')
-    api_collection.load_all('supports')
-
-
-def parse_compat_data(compat_data, local_collection):
-    local_collection.feature_slugs = set()
-    for key, value in compat_data['data'].items():
-        parse_compat_data_item(key, value, local_collection)
-
-    # Populate the sorted versions
-    browser_versions = defaultdict(list)
-    for version in local_collection.get_resources_by_data_id(
-            'versions').values():
-        browser_versions[version.browser.id].append(version)
-    for browser_id, versions in browser_versions.items():
-        browser = local_collection.get('browsers', browser_id)
-        browser.versions = sorted([v.id.id for v in versions])
-
-
-def slugify(word, attempt=0):
-    # TODO: replace with mdn.scrape.slugify
-    raw = word.lower().encode('utf-8')
-    out = []
-    acceptable = string.ascii_lowercase + string.digits + '_-'
-    for c in raw:
-        if c in acceptable:
-            out += str(c)
-        else:
-            out += '_'
-    slugged = ''.join(out)
-    while '__' in slugged:
-        slugged = slugged.replace('__', '_')
-    if attempt:
-        suffix = str(attempt)
-    else:
-        suffix = ""
-    with_suffix = slugged[slice(50 - len(suffix))] + suffix
-    return with_suffix.decode('utf-8')
-
-
-def unique_slugify(word, existing):
-    slug = slugify(word)
-    attempt = 0
-    while slug in existing:
-        attempt += 1
-        slug = slugify(word, attempt)
-    existing.add(slug)
-    return slug
-
-
-def parse_compat_data_item(key, item, local_collection):
+    known_browsers = [
+        "Chrome", "Firefox", "Internet Explorer", "Opera", "Safari", "Android",
+        "Chrome for Android", "Chrome Mobile", "Firefox Mobile", "IE Mobile",
+        "Opera Mini", "Opera Mobile", "Safari Mobile", "BlackBerry",
+        "Firefox OS"]
     browser_conversions = {
         "IE Phone": "IE Mobile",
         "Chrome for Andriod": "Chrome for Android",
@@ -170,9 +74,7 @@ def parse_compat_data_item(key, item, local_collection):
         "Windows Phone": "IE Mobile",
         "iOS Safari": "Safari Mobile",
     }
-    version_ignore = [
-        'notes',
-    ]
+    version_ignore = ['notes']
     support_map = {
         'y': u'yes',
         'u': u'unknown',
@@ -196,240 +98,156 @@ def parse_compat_data_item(key, item, local_collection):
         'Internet Explorer': u'-ms',
     }
 
-    if "breadcrumb" in item:
-        assert "contents" in item
-        assert "jsonselect" in item
-        assert "links" in item
+    def parse_compat_data_item(self, key, item, collection):
+        if "breadcrumb" in item:
+            assert "contents" in item
+            assert "jsonselect" in item
+            assert "links" in item
 
-        # Feature heirarchy
-        url = item['links'][0]["url"]
-        assert url.startswith('https://developer.mozilla.org/en-US/docs/')
-        mdn_subpath = url.split('en-US/docs/', 1)[1]
-        path_bits = mdn_subpath.split('/')
-        feature_id = ()
-        for bit in path_bits:
-            last_feature_id = feature_id
-            feature_id += (bit,)
-            if not local_collection.get('features', feature_id):
-                slug = unique_slugify(
-                    '-'.join(feature_id), local_collection.feature_slugs)
-                local_collection.add(Feature(
-                    id=feature_id, slug=slug, name={u'en': bit},
-                    experimental=False, obsolete=False, stable=True,
-                    standardized=True, mdn_uri=None,
-                    parent=last_feature_id or None))
-        parent_feature_id = feature_id
-        parent_feature = local_collection.get('features', parent_feature_id)
-        parent_feature.mdn_uri = {u'en': url}
-
-        for env, rows in item['contents'].items():
-            assert env in ('desktop', 'mobile')
-            for feature, columns in rows.items():
-                # Add feature
-                feature_id = parent_feature_id + (feature,)
-                if not local_collection.get('features', feature_id):
-                    slug = unique_slugify(
-                        '-'.join(feature_id), local_collection.feature_slugs)
-                    local_collection.add(Feature(
-                        id=feature_id, slug=slug,
-                        mdn_uri={u'en': url}, name={u'en': escape(feature)},
+            # Feature heirarchy
+            url = item['links'][0]["url"]
+            assert url.startswith('https://developer.mozilla.org/en-US/docs/')
+            mdn_subpath = url.split('en-US/docs/', 1)[1]
+            path_bits = mdn_subpath.split('/')
+            feature_id = ()
+            for bit in path_bits:
+                last_feature_id = feature_id
+                feature_id += (bit,)
+                if not collection.get('features', feature_id):
+                    slug = self.unique_slugify(
+                        '-'.join(feature_id), collection.feature_slugs)
+                    collection.add(Feature(
+                        id=feature_id, slug=slug, name={u'en': bit},
                         experimental=False, obsolete=False, stable=True,
-                        standardized=True, parent=parent_feature_id))
+                        standardized=True, mdn_uri=None,
+                        parent=last_feature_id or None))
+            parent_feature_id = feature_id
+            parent_feature = collection.get(
+                'features', parent_feature_id)
+            parent_feature.mdn_uri = {u'en': url}
 
-                # Add browser
-                for raw_browser, versions in columns.items():
-                    browser = browser_conversions.get(raw_browser, raw_browser)
-                    assert browser in known_browsers, raw_browser
-                    browser_id = known_browsers.index(browser)
-                    if not local_collection.get('browsers', browser_id):
-                        local_collection.add(Browser(
-                            id=browser_id, slug=slugify(browser),
-                            name={u'en': browser}, note=None))
+            for env, rows in item['contents'].items():
+                assert env in ('desktop', 'mobile')
+                for feature, columns in rows.items():
+                    # Add feature
+                    feature_id = parent_feature_id + (feature,)
+                    if not collection.get('features', feature_id):
+                        slug = self.unique_slugify(
+                            '-'.join(feature_id),
+                            collection.feature_slugs)
+                        collection.add(Feature(
+                            id=feature_id, slug=slug,
+                            mdn_uri={u'en': url},
+                            name={u'en': escape(feature)},
+                            experimental=False, obsolete=False, stable=True,
+                            standardized=True, parent=parent_feature_id))
 
-                    version_note = versions.get('notes', {})
-                    for raw_version, raw_support in versions.items():
-                        # Add version
-                        if raw_version in version_ignore:
-                            continue
-                        version, version_id = convert_version(
-                            browser_id, raw_version)
-                        if not local_collection.get('versions', version_id):
-                            local_collection.add(Version(
-                                id=version_id, version=version,
-                                browser=browser_id, note=None,
-                                release_day=None, release_notes_uri=None,
-                                retirement_day=None, status=u'unknown'))
+                    # Add browser
+                    for raw_browser, versions in columns.items():
+                        browser = self.browser_conversions.get(
+                            raw_browser, raw_browser)
+                        assert browser in self.known_browsers, raw_browser
+                        browser_id = self.known_browsers.index(browser)
+                        if not collection.get('browsers', browser_id):
+                            collection.add(Browser(
+                                id=browser_id, slug=self.slugify(browser),
+                                name={u'en': browser}, note=None))
 
-                        # Add support
-                        support_id = (version_id, feature_id)
-                        if not local_collection.get('supports', support_id):
-                            notes = []
-                            obj = Support(
-                                id=support_id, feature=feature_id,
-                                version=version_id, alternate_name=None,
-                                alternate_mandatory=False,
-                                default_config=None,
-                                note=None, prefix=None, prefix_mandatory=False,
-                                protected=False, requires_config=None)
-                            obj.support = support_map[raw_support[0]]
-                            if obj.support == 'prefix':
-                                obj.support = 'yes'
-                                obj.prefix = support_prefix[browser]
+                        version_note = versions.get('notes', {})
+                        for raw_version, raw_support in versions.items():
+                            # Add version
+                            if raw_version in self.version_ignore:
+                                continue
+                            version, version_id = self.convert_version(
+                                browser_id, raw_version)
+                            if not collection.get('versions', version_id):
+                                collection.add(Version(
+                                    id=version_id, version=version,
+                                    browser=browser_id, note=None,
+                                    release_day=None, release_notes_uri=None,
+                                    retirement_day=None, status=u'unknown'))
 
-                            if len(raw_support) > 1:
-                                notes.append(
-                                    'Original support string is "%s"'
-                                    % escape(raw_support))
-                            for item in version_note.items():
-                                notes.append('%s: %s' % item)
+                            # Add support
+                            support_id = (version_id, feature_id)
+                            if not collection.get('supports', support_id):
+                                notes = []
+                                obj = Support(
+                                    id=support_id, feature=feature_id,
+                                    version=version_id, alternate_name=None,
+                                    alternate_mandatory=False,
+                                    default_config=None, note=None,
+                                    prefix=None, prefix_mandatory=False,
+                                    protected=False, requires_config=None)
+                                obj.support = self.support_map[raw_support[0]]
+                                if obj.support == 'prefix':
+                                    obj.support = 'yes'
+                                    obj.prefix = self.support_prefix[browser]
 
-                            if notes:
-                                joined = '<br>'.join(escape(n) for n in notes)
-                                obj.note = {'en': joined}
-                            if obj.prefix:
-                                obj.prefix_mandatory = True
-                            local_collection.add(obj)
-    else:
-        for subkey, subitem in item.items():
-            parse_compat_data_item(subkey, subitem, local_collection)
+                                if len(raw_support) > 1:
+                                    notes.append(
+                                        'Original support string is "%s"'
+                                        % escape(raw_support))
+                                for item in version_note.items():
+                                    notes.append('%s: %s' % item)
 
-
-def convert_version(browser_id, raw_version):
-    if raw_version == '?':
-        version = None
-    else:
-        version = raw_version
-    if not version:
-        version = None
-        version_id = (browser_id,)
-    else:
-        assert version_re.match(version), raw_version
-        bits = tuple(int(x) for x in version.split('.'))
-        if len(bits) == 1:
-            # Prefer 12.0 format to 12 format
-            version += '.0'
-            bits += (0,)
-        version_id = (browser_id,) + bits
-    return version, version_id
-
-
-def select_subset(local_collection):
-    """Discard all but a subset of features and supports"""
-    # Select features to keep
-    keep_feature_ids = set()
-    for feature in local_collection.get_resources('features'):
-        if feature.mdn_uri and 'Web/CSS/c' in feature.mdn_uri['en']:
-            keep_feature_ids.add(feature.id.id)
-            parent = feature.parent.get()
-            while parent:
-                keep_feature_ids.add(parent.id.id)
-                parent = parent.parent.get()
-
-    # Discard unrelated supports
-    for support in local_collection.get_resources('supports')[:]:
-        if support.feature.id not in keep_feature_ids:
-            local_collection.remove(support)
-
-    # Discard unrelated features
-    for feature in local_collection.get_resources('features')[:]:
-        if feature.id.id not in keep_feature_ids:
-            local_collection.remove(feature)
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
-            return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
+                                if notes:
+                                    joined = '<br>'.join(
+                                        escape(n) for n in notes)
+                                    obj.note = {'en': joined}
+                                if obj.prefix:
+                                    obj.prefix_mandatory = True
+                                collection.add(obj)
         else:
-            print("Please type Y or N or D.")
+            for subkey, subitem in item.items():
+                self.parse_compat_data_item(subkey, subitem, collection)
+
+    version_re = re.compile("^[.\d]+$")
+
+    def convert_version(self, browser_id, raw_version):
+        if raw_version == '?':
+            version = None
+        else:
+            version = raw_version
+        if not version:
+            version = None
+            version_id = (browser_id,)
+        else:
+            assert self.version_re.match(version), raw_version
+            bits = tuple(int(x) for x in version.split('.'))
+            if len(bits) == 1:
+                # Prefer 12.0 format to 12 format
+                version += '.0'
+                bits += (0,)
+            version_id = (browser_id,) + bits
+        return version, version_id
+
+    def select_subset(self, collection):
+        """Discard all but a subset of features and supports"""
+        # Select features to keep
+        keep_feature_ids = set()
+        for feature in collection.get_resources('features'):
+            if feature.mdn_uri and 'Web/CSS/c' in feature.mdn_uri['en']:
+                keep_feature_ids.add(feature.id.id)
+                parent = feature.parent.get()
+                while parent:
+                    keep_feature_ids.add(parent.id.id)
+                    parent = parent.parent.get()
+
+        # Discard unrelated supports
+        for support in collection.get_resources('supports')[:]:
+            if support.feature.id not in keep_feature_ids:
+                collection.remove(support)
+
+        # Discard unrelated features
+        for feature in collection.get_resources('features')[:]:
+            if feature.id.id not in keep_feature_ids:
+                collection.remove(feature)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Initialize with compatibility data from webcompat project.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '--all-data', action="store_true",
-        help='Import all the data, rather than a subset')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    all_data = args.all_data
-    logger.info(
-        "Loading %s data into %s",
-        'all' if all_data else 'subset of', api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    compat_data = get_compat_data(COMPAT_DATA_FILENAME, COMPAT_DATA_URL)
-    counts = load_compat_data(
-        client, compat_data, all_data=all_data, confirm=confirm_changes)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    tool = LoadWebcompatData()
+    tool.init_from_command_line()
+    how_much = 'all' if tool.all_data else 'subset of'
+    tool.logger.info("Loading {} data into {}".format(how_much, tool.api))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/mirror_mdn_features.py
+++ b/tools/mirror_mdn_features.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from cgi import escape
+from json import loads
+from string import lowercase
+import time
+
+from common import Tool
+from resources import Collection, Feature
+
+
+class MirrorMDNFeatures(Tool):
+    """Create and Update API features for MDN pages."""
+    logger_name = 'tools.mirror_mdn_features'
+    parser_options = ['api', 'user', 'password', 'data']
+    base_mdn_domain = 'https://developer.mozilla.org'
+    base_mdn_uri = base_mdn_domain + '/en-US/docs/'
+    rate = 5
+
+    def __init__(self, *args, **kwargs):
+        super(MirrorMDNFeatures, self).__init__(*args, **kwargs)
+        self.rate_limit_start = time.time()
+        self.rate_limit_requests = 0
+
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        self.logger.info('Reading existing features from API')
+        api_collection.load_all('features')
+
+        # Copy feature to working local collection
+        local_collection = Collection()
+        local_collection.load_collection(api_collection)
+        features = self.known_features(local_collection)
+        feature_by_uri = dict((k[0], k[2]) for k in features)
+        feature_by_slug = dict((k[1], k[2]) for k in features)
+        slugs = set(feature_by_slug.keys())
+
+        self.logger.info('Reading pages from MDN')
+        mdn_uris = self.current_mdn_uris()
+
+        new_page, needs_url, existing_page = 0, 0, 0
+        for path, parent_path, raw_slug, title in mdn_uris:
+            uri = self.base_mdn_domain + path
+            feature = feature_by_uri.get(uri)
+            if feature:
+                existing_page += 1
+                feature.name = self.to_trans(title)
+            else:
+                slug = self.unique_slugify(raw_slug, slugs)
+                feature = feature_by_slug.get(slug)
+                if feature:
+                    # Need to add URI to feature
+                    feature.mdn_uri = {'en': uri}
+                    feature_by_uri[uri] = feature
+                    needs_url += 1
+                else:
+                    if parent_path:
+                        parent_uri = self.base_mdn_domain + parent_path
+                        parent_feature = feature_by_uri.get(parent_uri)
+                        assert parent_feature,\
+                            'No feature for parent page {}'.format(parent_uri)
+                        parent_id = parent_feature.id.id
+                    else:
+                        parent_id = None
+                    feature = Feature(
+                        id='_' + slug, slug=slug, mdn_uri={'en': uri},
+                        name=self.to_trans(title), parent=parent_id)
+                    local_collection.add(feature)
+                    feature_by_uri[uri] = feature
+                    feature_by_slug[slug] = feature
+        self.logger.info(
+            'MDN URIs gathered, %d found (%d new, %d needs url, %d existing).',
+            len(mdn_uris), new_page, needs_url, existing_page)
+
+        return self.sync_changes(api_collection, local_collection)
+
+    def to_trans(self, text):
+        """Convert text to an API translatable string.
+
+        If it looks canonical, convert to display in a <code></code> tag.
+        If it looks like English, convert to display in <div></div> tag.
+        """
+        if ' ' in text:
+            canonical = False
+        elif text[0] in lowercase:
+            canonical = True
+        elif text[0] == '<' and text[-1] == ">":
+            canonical = True
+        elif text[0] == ':':
+            canonical = True
+        elif text[0].endswith("()"):
+            canonical = True
+        else:
+            canonical = False
+        if canonical:
+            return escape(text)
+        else:
+            return {'en': escape(text)}
+
+    def current_mdn_uris(self):
+        """Load potential URIs from MDN."""
+        base_paths = [
+            'Web', 'Navigation_timing', 'Server-sent_events', 'WebAPI',
+            'WebSockets']
+        headers = {'Accept': 'application/json'}
+
+        data = []
+        for base_path in base_paths:
+            cache_file = base_path + "_mdn_children.json"
+            mdn_uri = self.base_mdn_uri + base_path + '$children'
+            children = self.cached_download(
+                cache_file, mdn_uri, headers=headers, retries=60)
+            data.extend(self.gather_mdn_json(loads(children)))
+        return data
+
+    def known_features(self, collection):
+        """Load URIs from collection's features."""
+        uris = []
+        for feature in collection.get_resources('features'):
+            uri = feature.mdn_uri and feature.mdn_uri.get('en')
+            slug = feature.slug
+            uris.append((uri, slug, feature))
+        return uris
+
+    def gather_mdn_json(self, mdn_json, parent_path=None):
+        """Recursively gather data from MDN JSON."""
+        path = mdn_json['url']
+        title = mdn_json['title']
+        slug = mdn_json['slug']
+        subpages = mdn_json['subpages']
+        data = [(path, parent_path, slug, title)]
+        for subjson in subpages:
+            data.extend(self.gather_mdn_json(subjson, path))
+        return data
+
+    def rate_limit(self):
+        """Pause and return True if exceeding the rate limit."""
+        self.rate_limit_requests += 1
+
+        # Sleep if we need to wait for the rate limit
+        current_time = time.time()
+        if self.rate:
+            elapsed = current_time - self.rate_limit_start
+            target = (
+                self.rate_limit_start +
+                float(self.rate_limit_requests) / self.rate)
+            current_rate = float(self.rate_limit_requests) / elapsed
+            if current_time < target:
+                rest = int(target - current_time) + 1
+                self.logger.warning(
+                    "%d pages fetched, %0.2f per second, target rate %d per"
+                    " second.  Resting %d seconds.",
+                    self.rate_limit_requests, current_rate, self.rate, rest)
+                time.sleep(rest)
+                return True
+        return False
+
+
+if __name__ == '__main__':
+    tool = MirrorMDNFeatures()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}...".format(tool=tool))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -339,13 +339,13 @@ class Section(Resource):
         'history': ('historical_sections', True),
         'history_current': ('historical_sections', False),
     }
-    _id_data = ('number_en', 'specification.mdn_key')
+    _id_data = ('specification.mdn_key', 'subpath_en')
 
     @property
-    def number_en(self):
-        if self.number is None:
+    def subpath_en(self):
+        if self.subpath is None:
             return None
-        return self.number.get('en', None)
+        return self.subpath.get('en', None)
 
 
 class Maturity(Resource):

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -104,7 +104,7 @@ class Resource(object):
         self._collection = collection
 
         assert hasattr(self, '_resource_type'), "Must set _resource_type"
-        assert hasattr(self, '_id_data'), "Must set _unique index"
+        assert hasattr(self, '_id_data'), "Must set _id_data"
         assert tuple(sorted(self._id_data)) == tuple(self._id_data), \
             "_id_data must be sorted"
 
@@ -682,9 +682,8 @@ class CollectionChangeset(object):
 
         # Summarize new resources
         for item in self.changes['new'].values():
-            resource_type = item._resource_type
             rep = self.format_item(item)
-            out.append("New %s:\n%s" % (resource_type, rep))
+            out.append("New:\n%s" % rep)
 
         # Summarize deleted resources
         for item in self.changes['deleted'].values():

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -462,6 +462,23 @@ class Collection(object):
         done_count = len(self._repository.get(resource_type, []))
         return done_count - original_count
 
+    def load_collection(self, from_collection):
+        """Load data from another collection.
+
+        This is useful for loading an original collection, altering the
+        resources, and then syncing the changes back to the original
+        collection.
+        """
+        assert not self.client, "Don't set client when using load_collection."
+        assert not self._repository, "Can't load with existing resources"
+        for data_id, resource in from_collection.get_all_by_data_id().items():
+            json_api = resource.to_json_api()
+            if resource.id:
+                json_api[resource._resource_type]['id'] = resource.id.id
+            new_resource = type(resource)()
+            new_resource.from_json_api(json_api)
+            self.add(new_resource)
+
     def override_ids_to_match(self, sync_collection):
         """Change IDs to match another collection."""
         self._override_ids = {}

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -222,7 +222,18 @@ class Resource(object):
         data = OrderedDict()
         for field in self._writeable_property_fields:
             if field in self._data:
-                data[field] = self._data[field]
+                raw_value = self._data[field]
+                if hasattr(raw_value, 'keys') and 'en' in raw_value:
+                    # Sort languages
+                    value = OrderedDict()
+                    value['en'] = raw_value['en']
+                    for lang in sorted(raw_value.keys()):
+                        if lang != 'en':
+                            value[lang] = raw_value[lang]
+                else:
+                    value = raw_value
+
+                data[field] = value
         for field, attr in self._writeable_link_fields.items():
             is_sorted = attr[1] == Resource.SORTED
             if not with_sorted and is_sorted:

--- a/tools/sample_mdn.py
+++ b/tools/sample_mdn.py
@@ -1,50 +1,57 @@
 #!/usr/bin/env python
-
 from __future__ import print_function
+
 import re
-import os.path
 import random
-import urllib
 import webbrowser
 
+from common import Tool
+
+try:
+    input = raw_input  # Py2?
+except NameError:
+    pass  # Nope Py3
+
 re_url = re.compile(r'\s*"url":\s"([^"]*)"')
-count = 0
 
-print("Go through data-human.json, and open each in the browser")
 
-# Fetch the file from github
-filename = "data-human.json"
-if not os.path.exists(filename):
-    print("Downloading data-human.json")
-    url = (
-        "https://raw.githubusercontent.com/webplatform/compatibility-data"
-        "/master/data-human.json")
-    urllib.urlretrieve(url, filename)
+class SampleMDN(Tool):
+    """Open a random MDN URL scraped from the webcompat project."""
+    logger_name = 'tools.sample_mdn'
 
-# Extract the URLs
-urls = []
-with open(filename, 'r') as f:
-    for raw_line in f:
-        line = raw_line.strip()
-        match = re_url.match(line)
-        if match:
-            url = match.group(1)
-            urls.append(url)
+    def run(self, *args, **kwargs):
+        count = 0
+        urls = self.get_urls()
+        while True:
+            url = random.choice(urls)
+            self.logger.info("%d: %s", count, url)
+            count += 1
+            webbrowser.open(url + '#Specifications')
+            x = input("Enter to continue, or q+Enter to quit: ")
 
-# Open them
-count = 0
-while True:
-    print("%d: %s" % (count, url))
-    count += 1
-    url = random.choice(urls)
-    webbrowser.open(url + '#Specifications')
-    try:
-        input = raw_input  # Py2?
-    except NameError:
-        pass  # Nope Py3
-    x = input("Enter to continue, or q+Enter to quit: ")
+            if x == 'q':
+                break
 
-    if x == 'q':
-        break
+        self.logger.info("%d URLs visited" % count)
+        return count
 
-print("%d URLs visited" % count)
+    def get_urls(self):
+        data_human = self.cached_download(
+            'data-human.json',
+            "https://raw.githubusercontent.com/webplatform/compatibility-data"
+            "/master/data-human.json")
+
+        urls = []
+        for raw_line in data_human.split('\n'):
+            line = raw_line.strip()
+            match = re_url.match(line)
+            if match:
+                url = match.group(1)
+                urls.append(url)
+        return urls
+
+
+if __name__ == '__main__':
+    tool = SampleMDN()
+    tool.init_from_command_line()
+    tool.run()

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -745,6 +745,34 @@ class TestCollection(TestCase):
         self.col.remove(firefox)
         self.assertEqual([], self.col.get_resources('browsers'))
 
+    def test_load_collection(self):
+        firefox = Browser(slug='firefox')
+        self.col.add(firefox)
+        key = ('browsers', 'firefox')
+        self.assertEqual(
+            {key: firefox}, self.col.get_resources_by_data_id('browsers'))
+        copy_col = Collection()
+        copy_col.load_collection(self.col)
+        new_resources = copy_col.get_resources_by_data_id('browsers')
+        self.assertEqual([key], list(new_resources.keys()))
+        new_firefox = new_resources[key]
+        self.assertEqual(firefox.to_json_api(), new_firefox.to_json_api())
+        self.assertIsNone(firefox.id)
+
+    def test_load_collection_with_id(self):
+        firefox = Browser(slug='firefox', id=6)
+        self.col.add(firefox)
+        key = ('browsers', 'firefox')
+        self.assertEqual(
+            {key: firefox}, self.col.get_resources_by_data_id('browsers'))
+        copy_col = Collection()
+        copy_col.load_collection(self.col)
+        new_resources = copy_col.get_resources_by_data_id('browsers')
+        self.assertEqual([key], list(new_resources.keys()))
+        new_firefox = new_resources[key]
+        self.assertEqual(firefox.to_json_api(), new_firefox.to_json_api())
+        self.assertEqual(new_firefox.id.id, 6)
+
 
 class TestCollectionChangeset(TestCase):
 

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -825,13 +825,13 @@ class TestCollectionChangeset(TestCase):
     def test_summary_new_items(self):
         _, cc = self.setup_new()
         expected = """\
-New browsers:
+New:
 {
   "browsers": {
     "slug": "chrome"
   }
 }
-New versions:
+New:
 {
   "versions": {
     "version": "2.0",
@@ -908,13 +908,13 @@ New versions:
     def test_summary_new_items_with_dependencies(self):
         _, cc = self.setup_new_with_dependencies()
         expected = """\
-New features:
+New:
 {
   "features": {
     "slug": "parent"
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child1",
@@ -923,7 +923,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child2",
@@ -932,7 +932,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child3",
@@ -941,7 +941,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "grandchild",

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -367,13 +367,13 @@ class TestSection(TestCase):
         feature = Feature(id="222")
         section = Section(
             id="_sec", specification="22", features=["222"],
-            number={"en": "1.2.3"})
+            number={"en": "1.2.3"}, subpath={"en": "#123"})
         collection = Collection()
         collection.add(maturity)
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '1.2.3', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', '#123'), section.get_data_id())
 
     def test_without_number(self):
         section = Section(
@@ -388,7 +388,7 @@ class TestSection(TestCase):
                 }}}
         self.assertEqual(expected, section.to_json_api())
 
-    def test_get_data_id_without_number(self):
+    def test_get_data_id_without_subpath(self):
         maturity = Maturity(id="2")
         spec = Specification(id="22", maturity="2", mdn_key="SPEC")
         feature = Feature(id="222")
@@ -398,7 +398,7 @@ class TestSection(TestCase):
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', ''), section.get_data_id())
 
     def test_with_empty_number(self):
         section = Section(
@@ -414,18 +414,18 @@ class TestSection(TestCase):
                 }}}
         self.assertEqual(expected, section.to_json_api())
 
-    def test_get_data_id_with_empty_number(self):
+    def test_get_data_id_with_empty_subpath(self):
         maturity = Maturity(id="2")
         spec = Specification(id="22", maturity="2", mdn_key="SPEC")
         feature = Feature(id="222")
         section = Section(
-            id="_sec", specification="22", features=["222"], number={})
+            id="_sec", specification="22", features=["222"], subpath={})
         collection = Collection()
         collection.add(maturity)
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', ''), section.get_data_id())
 
 
 class TestMaturity(TestCase):
@@ -478,7 +478,7 @@ class TestCollection(TestCase):
         specification = Specification(
             id='6', slug='css1', mdn_key='CSS1', maturity='5')
         self.col.add(specification)
-        section = Section(id='7', number={'en': '5.6.1'}, specification='6')
+        section = Section(id='7', subpath={'en': '#561'}, specification='6')
         self.col.add(section)
 
         index = self.col.get_all_by_data_id()
@@ -489,7 +489,7 @@ class TestCollection(TestCase):
             ('supports', 'the-feature', 'chrome', '1.0'): support,
             ('maturities', 'REC'): maturity,
             ('specifications', 'CSS1'): specification,
-            ('sections', '5.6.1', 'CSS1'): section,
+            ('sections', 'CSS1', '#561'): section,
         }
         self.assertEqual(expected, index)
 

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -1,193 +1,63 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 from collections import OrderedDict
 import codecs
-import getpass
 import json
-import logging
-import os.path
-import sys
 
-from client import Client
-from resources import Collection, CollectionChangeset
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
-
-logger = logging.getLogger('tools.upload_data')
-
-resources = [
-    'browsers',
-    'versions',
-    'features',
-    'supports',
-    'specifications',
-    'maturities',
-    'sections',
-]
+from common import Tool
+from resources import Collection
 
 
-def upload_data(client, base_dir='', confirm=None):
-    """Upload data to the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+class UploadData(Tool):
+    """Upload data to the API."""
+    logger_name = 'tools.upload_data'
+    parser_options = ['api', 'user', 'password', 'data']
 
-    logger.info('Reading existing data from API')
-    load_api_data(api_collection)
-    logger.info('Reading upload data from disk')
-    load_local_data(local_collection, base_dir)
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        local_collection = Collection()
+        resources = [
+            'browsers', 'versions', 'features', 'supports', 'specifications',
+            'maturities', 'sections']
 
-    logger.info('Looking for changes...')
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
+        self.logger.info('Reading existing data from API')
+        for resource in resources:
+            count = api_collection.load_all(resource)
+            self.logger.info("Downloaded %d %s.", count, resource)
 
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
+        self.logger.info('Reading upload data from disk')
+        for resource in resources:
+            filepath = self.data_file('{}.json'.format(resource))
+            with codecs.open(filepath, 'r', 'utf8') as f:
+                data = json.load(f, object_pairs_hook=OrderedDict)
+            resource_class = local_collection.resource_by_type[resource]
+            for item in data[resource]:
+                obj = resource_class()
+                obj.from_json_api({resource: item})
+                local_collection.add(obj)
 
-    counts = changeset.change_original_collection()
-    return counts
+        return self.sync_changes(api_collection, local_collection)
 
+    def get_parser(self):
+        parser = super(UploadData, self).get_parser()
+        parser.add_argument(
+            '--noinput', action="store_true",
+            help='Upload any changes without prompting the user for input')
+        return parser
 
-def load_api_data(api_collection):
-    for resource in resources:
-        count = api_collection.load_all(resource)
-        logger.info("Downloaded %d %s.", count, resource)
-
-
-def load_local_data(local_collection, base_dir):
-    for resource in resources:
-        filepath = os.path.join(base_dir, '%s.json' % resource)
-        with codecs.open(filepath, 'r', 'utf8') as f:
-            data = json.load(f, object_pairs_hook=OrderedDict)
-        resource_class = local_collection.resource_by_type[resource]
-        for item in data[resource]:
-            obj = resource_class()
-            obj.from_json_api({resource: item})
-            local_collection.add(obj)
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
+    def confirm_changes(self, changeset):
+        if self.noinput:
             return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
         else:
-            print("Please type Y or N or D.")
+            return super(UploadData, self).confirm_changes(changeset)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Upload data to the API.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-p', '--password',
-        help='Password on API (default: prompt for password)')
-    parser.add_argument(
-        '-d', '--data', default='data',
-        help='Input data folder (default: data)')
-    parser.add_argument(
-        '--noinput', action="store_true",
-        help='Upload any changes without prompting the user for input')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    fmat = '%(levelname)s - %(message)s'
-    logger_name = 'tools'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    data = args.data
-    if data.endswith('/'):
-        data = data[:-1]
-    logger.info("Uploading data from %s to %s", data, api)
-
-    # Get credentials
-    user = args.user
-    password = args.password
-    if args.noinput and not (user and password):
+    tool = UploadData()
+    tool.init_from_command_line()
+    tool.logger.info(
+        "Uploading data from {tool.data} to {tool.api}".format(tool=tool))
+    if tool.noinput and not (tool.user and tool.password):
         raise Exception("--noinput requires --user and --password")
-    else:
-        if not user:
-            user = input("API username: ")
-        if not password:
-            password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    confirm = None if args.noinput else confirm_changes
-    counts = upload_data(client, data, confirm)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/webplatformcompat/drf_fields.py
+++ b/webplatformcompat/drf_fields.py
@@ -210,13 +210,16 @@ class TranslatedTextField(CharField):
         if value:
             value = value.strip()
         if value:
-            try:
-                native = json.loads(value)
-            except ValueError as e:
-                if self.allow_canonical:
-                    native = str(value)
-                else:
-                    raise ValidationError(str(e))
+            if value[0] in '"{':
+                try:
+                    native = json.loads(value)
+                except ValueError as e:
+                    if self.allow_canonical:
+                        native = value
+                    else:
+                        raise ValidationError(str(e))
+            else:
+                native = value
             if isinstance(native, six.string_types) and self.allow_canonical:
                 return {'zxx': native}
             else:

--- a/webplatformcompat/tests/test_drf_fields.py
+++ b/webplatformcompat/tests/test_drf_fields.py
@@ -79,6 +79,12 @@ class TestTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
         self.assertRaises(
             ValidationError, self.ttf.to_internal_value, bad_json)
 
+    def test_to_internal_value_string_true(self):
+        self.assertEqual('false', self.ttf.to_internal_value('false'))
+
+    def test_to_internal_value_list(self):
+        self.assertEqual('["list"]', self.ttf.to_internal_value('["list"]'))
+
 
 class TestCanonTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
 
@@ -100,6 +106,13 @@ class TestCanonTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
         bad_json = "{'quotes': 'wrong ones'}"
         expected = {"zxx": "{'quotes': 'wrong ones'}"}
         self.assertEqual(expected, self.ttf.to_internal_value(bad_json))
+
+    def test_to_internal_value_string_true(self):
+        self.assertEqual({'zxx': 'false'}, self.ttf.to_internal_value('false'))
+
+    def test_to_internal_value_list(self):
+        self.assertEqual(
+            {'zxx': '["list"]'}, self.ttf.to_internal_value('["list"]'))
 
 
 class SharedOptionalCharFieldTests(object):


### PR DESCRIPTION
*This builds on PR #29 (bug 1154349), and can be rebased after a merge*

This code adds the abilty to scrape MDN pages into "branch" features, so that the importer can parse out in-page specification and browser compatibility data ("leaf" features).

The code is running on https://browsercompat.herokuapp.com, and features have been added to mirror MDN pages, bringing the total to [6042 features](https://browsercompat.herokuapp.com/browse/features).  Additionally, [specifications](https://browsercompat.herokuapp.com/browse/specifications), [maturities](https://browsercompat.herokuapp.com/browse/maturities), and [versions](https://browsercompat.herokuapp.com/browse/browsers) have been synced with MDN.  There are now [6239 known issues](https://browsercompat.herokuapp.com/importer/issues) with MDN pages, with many critical errors that may mask additional issues.

The commits can be split into three parts:

**Refactor tools to prepare for new tools and tools upgrades**

Prepare for adding another tool. Common code is extracted to tools/common.py, standardizing command-line parsing in ToolParser and shared functionality in the Tool class. Tools are re-written to derive from the Tool class.  Some issues were found and fixed during manual testing.

**Add tools/mirror_mdn_features.py**

This new tool creates branch features for all MDN pages under Web, Navigation_timing, Server-sent_events, WebAPI, and WebSockets. This includes pages without compatibility data, since that can't be determined without scraping the pages themselves. It also updates names and URIs, fixing some missing data from the webplatform data.  Additional API improvements were needed to handle the expanded MDN page titles.

**Update importer for expanded data**

With branch features representing MDN pages, the importer can scrape the leaf features with the tools/import_mdn.py. Getting it to run successfully required several changes and improvements.  Highlights are:

- Pages without compatibility data are now marked with a "no data" status
- A new issue "doc_parse_issue" is used for pages where the parser can't determine if there is or isn't compatibility data, replacing the "false_start" issue.
- Additional assertions triggered by the new data were converted into issues such as "specname_blank_key".
- Redirected pages are reflected in the database.
- Deleted pages are skipped without halting the import.
- Translations are gathered for branch pages with localized names 

There are still parser improvements needed, and lots of page cleanup.  Those can be added to [bug 1132269](https://bugzilla.mozilla.org/show_bug.cgi?id=1132269).