### PR TITLE
Fix bug 1132677 -  Parse inconsistent specification table cells

### DIFF
--- a/mdn/models.py
+++ b/mdn/models.py
@@ -387,6 +387,16 @@ ISSUES = OrderedDict((
         ERROR,
         'KumaScript SpecName has a blank key',
         'Update the MDN page to include a valid mdn_key')),
+    ('specname_converted', (
+        WARNING,
+        'Specification name should be converted to KumaScript',
+        'The specification "{original}" should be replaced with the KumaScript'
+        ' {{{{SpecName({key})}}}}')),
+    ('specname_not_kumascript', (
+        ERROR,
+        'Specification name unknown, and should be converted to KumaScript',
+        'Expected KumaScript {{{{SpecName(key, subpath, name)}}}}, but got'
+        ' text "{original}".')),
     ('spec2_wrong_kumascript', (
         ERROR,
         'Expected KumaScript Spec2(), got {kumascript}',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -406,6 +406,11 @@ ISSUES = OrderedDict((
         ERROR,
         'KumaScript {kumascript} should have 1 non-blank argument',
         'Argument should be the MDN key that will return a maturity')),
+    ('spec2_converted', (
+        WARNING,
+        'Specification status should be converted to KumaScript',
+        'Expected KumaScript {{{{Spec2("{key}")}}}}, but got text'
+        ' "{original}".')),
     ('unexpected_attribute', (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -364,13 +364,13 @@ class PageVisitor(NodeVisitor):
             except Specification.DoesNotExist:
                 spec_id = None
                 self.issues.append((
-                    'unknown_spec', node.start, node.end, {'key': key}))
+                    'unknown_spec', item['start'], item['end'], {'key': key}))
             else:
                 spec_id = spec.id
         else:
             if item['type'] == 'kumascript':
                 self.issues.append((
-                    'specname_blank_key', node.start, node.end, {}))
+                    'specname_blank_key', item['start'], item['end'], {}))
             spec_id = None
 
         return (key, spec_id, subpath, name)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -314,12 +314,23 @@ class ScrapeTestCase(TestCase):
 </ul>""" % sample_spec_section
     _instance_specs = {
         (Maturity, 'CR'): {'name': '{"en": "Candidate Recommendation"}'},
+        (Maturity, 'WD'): {'name': '{"en": "Working Draft"}'},
         (Specification, 'css3_backgrounds'): {
             '_req': {'maturity': (Maturity, 'CR')},
             'mdn_key': 'CSS3 Backgrounds',
             'name': (
                 '{"en": "CSS Backgrounds and Borders Module Level&nbsp;3"}'),
             'uri': '{"en": "http://dev.w3.org/csswg/css3-background/"}'},
+        (Specification, 'css3_ui'): {
+            '_req': {'maturity': (Maturity, 'WD')},
+            'mdn_key': 'CSS3 UI',
+            'name': '{"en": "CSS Basic User Interface Module Level&nbsp;3"}',
+            'uri': '{"en": "http://dev.w3.org/csswg/css3-ui/"}'},
+        (Specification, 'web_audio_api'): {
+            '_req': {'maturity': (Maturity, 'WD')},
+            'mdn_key': 'Web Audio API',
+            'name': '{"en": "Web Audio API"}',
+            'uri': '{"en": "http://webaudio.github.io/web-audio-api/"}'},
         (Section, 'background-size'): {
             '_req': {'specification': (Specification, 'css3_backgrounds')},
             'subpath': '{"en": "#the-background-size"}'},
@@ -449,6 +460,7 @@ class TestPageVisitor(ScrapeTestCase):
         self.assertEqual(issues, self.visitor.issues)
 
     def test_spec_row_mismatch(self):
+        spec = self.get_instance(Specification, 'css3_ui')
         spec_row = '''\
 <tr>
   <td>{{ SpecName('CSS3 UI', '#cursor', 'cursor') }}</td>
@@ -464,9 +476,8 @@ class TestPageVisitor(ScrapeTestCase):
             'section.name': 'cursor',
             'specification.mdn_key': 'CSS3 UI',
             'section.id': None,
-            'specification.id': None}]
+            'specification.id': spec.id}]
         issues = [
-            ('unknown_spec', 7, 62, {'key': 'CSS3 UI'}),
             ('spec_mismatch', 0, 199,
              {'spec2_key': 'CSS3 Basic UI', 'specname_key': 'CSS3 UI'})]
         self.assert_spec_row(spec_row, expected_specs, issues)
@@ -498,6 +509,7 @@ class TestPageVisitor(ScrapeTestCase):
 
     def test_spec_row_no_thead(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+        spec = self.get_instance(Specification, 'web_audio_api')
         spec_row = '''\
 <tr>
   <td>{{SpecName('Web Audio API', '#the-audiocontext-interface',\
@@ -511,9 +523,8 @@ class TestPageVisitor(ScrapeTestCase):
             'section.name': 'AudioContext',
             'specification.mdn_key': 'Web Audio API',
             'section.id': None,
-            'specification.id': None}]
-        issues = [('unknown_spec', 7, 92, {'key': 'Web Audio API'})]
-        self.assert_spec_row(spec_row, expected_specs, issues)
+            'specification.id': spec.id}]
+        self.assert_spec_row(spec_row, expected_specs, [])
 
     def test_spec_row_known_spec(self):
         spec = self.get_instance(Specification, 'css3_backgrounds')
@@ -1640,17 +1651,17 @@ class TestScrape(ScrapeTestCase):
 
     def test_spec_only(self):
         """Test with a only a Specification section."""
+        spec = self.get_instance(Specification, 'css3_backgrounds')
         page = self.sample_spec_section
         specs = [{
             'specification.mdn_key': 'CSS3 Backgrounds',
-            'specification.id': None,
+            'specification.id': spec.id,
             'section.subpath': '#the-background-size',
             'section.name': 'background-size',
             'section.note': '',
             'section.id': None,
         }]
-        issues = [('unknown_spec', 251, 335, {'key': 'CSS3 Backgrounds'})]
-        self.assertScrape(page, specs, issues)
+        self.assertScrape(page, specs, [])
 
 
 class FeaturePageTestCase(ScrapeTestCase):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -504,7 +504,7 @@ class TestPageVisitor(ScrapeTestCase):
             'specification.mdn_key': 'HTML WHATWG',
             'section.id': None,
             'specification.id': None}]
-        issues = [('unknown_spec', 7, 179, {'key': 'HTML WHATWG'})]
+        issues = [('unknown_spec', 11, 174, {'key': 'HTML WHATWG'})]
         self.assert_spec_row(spec_row, expected_specs, issues)
 
     def test_spec_row_no_thead(self):
@@ -569,14 +569,14 @@ class TestPageVisitor(ScrapeTestCase):
         # https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent
         specname_td = '<td>{{SpecName("Device Orientation")}}</td>'
         expected = ("Device Orientation", None, '', '')
-        issues = [('unknown_spec', 0, 43, {'key': 'Device Orientation'})]
+        issues = [('unknown_spec', 4, 38, {'key': 'Device Orientation'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_empty_key(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/MIDIConnectionEvent
         specname_td = "<td>{{SpecName('', '#midiconnection')}}</td>"
         expected = ('', None, '#midiconnection', '')
-        issues = [('specname_blank_key', 0, 44, {})]
+        issues = [('specname_blank_key', 4, 39, {})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_ES1_legacy(self):
@@ -586,7 +586,7 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [
             ('specname_converted', 4, 27,
              {'original': 'ECMAScript 1st Edition.', 'key': 'ES1'}),
-            ('unknown_spec', 0, 32, {'key': 'ES1'})]
+            ('unknown_spec', 4, 27, {'key': 'ES1'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_ES3_legacy(self):
@@ -596,7 +596,7 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [
             ('specname_converted', 5, 29,
              {'original': 'ECMAScript 3rd Edition.', 'key': 'ES3'}),
-            ('unknown_spec', 0, 34, {'key': 'ES3'})]
+            ('unknown_spec', 5, 29, {'key': 'ES3'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_other(self):

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -46,7 +46,7 @@ class GatherImportIssues(Tool):
             "MDN Slug", "Import URL", "Issue Slug", "Source Start",
             "Source End", "Params"])
         for row in issue_rows:
-            err = row[4]
+            err = row[2]
             issue_counts[err] += 1
             by_url_writer.writerow(row)
 


### PR DESCRIPTION
*This builds on PR #31, and can be rebased once that is accepted.*

Expand allowed content in the first two columns of the specification tables.  The KumaScript SpecName and Spec2 macros are still the only accepted content, but other content will result in issues rather than broken parsing.  New issues types are added:

* **specname_converted** (warning) - If the text is "ECMAScript 1st Edition." or "ECMAScript 3rd Edition.", then it is treated as ES1 and ES3.
* **specname_not_kumascript** (error) - Other non-KumaScript text, including links, is an error
* **spec2_converted** (warning) - If the second column is not a Spec2 macro, a warning is issued and the value discarded.

There were 6230 issues before this change, and there are 6294 now:

Issue | Count Before | Count After
-----|----|----|
section_skipped | 2685 | 2042
inline_text | 1352 | 1436
doc_parse_error | 408 | 408
halt_import | 369 | 429
footnote_no_id | 301 | 305
unknown_kumascript | 294 | 302
unexpected_attribute | 292 | 292
spec2_converted | (n/a) | 255
specname_converted | (n/a) | 188
unknown_version | 149 | 151
footnote_missing | 137 | 137
specname_not_kumascript | (n/a) | 87
footnote_multiple | 40 | 40
spec_h2_id | 38 | 38
section_missed | 37 | 29
spec_h2_name | 32 | 32
unknown_spec | 24 | 24
footnote_unused | 20 | 20
unknown_browser | 16 | 18
spec_mismatch | 16 | 32
compatgeckodesktop_unknown | 8 | 8
spec2_arg_count | 5 | 5
specname_blank_key | 4 | 4
spec2_wrong_kumascript | 4 | 4
footnote_feature | 3 | 3
extra_cell | 3 | 3
feature_header | 2 | 2