### PR TITLE
Fix bug 1134373 - Parse KumaScript in Specification comments

### DIFF
--- a/mdn/models.py
+++ b/mdn/models.py
@@ -433,6 +433,10 @@ ISSUES = OrderedDict((
         'Specification status should be converted to KumaScript',
         'Expected KumaScript {{{{Spec2("{key}")}}}}, but got text'
         ' "{original}".')),
+    ('specdesc_spec2_invalid', (
+        ERROR,
+        '{kumascript} is invalid in the spec description',
+        'Handled as if {{{{SpecName(...)}}}} was used. Update the MDN page.')),
     ('unexpected_attribute', (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -72,7 +72,10 @@ specname_td = td_open _ specname_text "</td>"
 specname_text = kumascript / inner_td
 spec2_td = td_open _ spec2_text "</td>"
 spec2_text = kumascript / inner_td
-specdesc_td = td_open _ inner_td _ "</td>"
+specdesc_td = td_open _ specdesc_text _ "</td>"
+specdesc_text = specdesc_token*
+specdesc_token = kumascript / code_block / spec_other
+spec_other = ~r"(?P<content>[^{<]+)\s*"s
 inner_td = ~r"(?P<content>.*?(?=</td>))"s
 
 #
@@ -105,8 +108,8 @@ compat_row_cell = td_open _ compat_cell _ "</td>" _
 #   Due to rowspan and colspan usage, we won't know if a cell is a feature
 #   or a support until we visit the table.
 #
-compat_cell = compat_cell_item*
-compat_cell_item = (kumascript / cell_break / code_block / cell_p_open /
+compat_cell = compat_cell_token*
+compat_cell_token = (kumascript / cell_break / code_block / cell_p_open /
     cell_p_close / cell_version / cell_footnote_id / cell_removed / cell_other)
 cell_break = "<" _ "br" _ ("/>" / ">") _
 code_block = "<code>" _ code_text _ "</code>" _
@@ -215,9 +218,15 @@ class PageVisitor(NodeVisitor):
         """Visitor when none is specified."""
         return visited_children or node
 
-    def _visit_content(self, node, args):
+    def _visit_content(self, node, children):
         """Vistor for re nodes with a named (?P<content>) section."""
         return node.match.group('content')
+
+    def _visit_token(self, node, children):
+        """Visitor for one of many tokenized items"""
+        token = children[0]
+        assert isinstance(token, dict), type(token)
+        return token
 
     def visit_doc(self, node, children):
         """At the top level, return all the collected data."""
@@ -406,10 +415,39 @@ class PageVisitor(NodeVisitor):
         return key
 
     def visit_specdesc_td(self, node, children):
-        item = children[2]
-        assert isinstance(item, dict), type(item)
-        assert item['type'] == 'text'
-        return item['content']
+        specdesc = children[2]
+        bits = []
+        if isinstance(specdesc, Node):
+            assert specdesc.start == specdesc.end
+        else:
+            assert isinstance(specdesc, list), type(specdesc)
+            for item in specdesc:
+                if item['type'] == 'kumascript':
+                    if item['name'] == 'xref_csslength':
+                        assert not item['args']
+                        bits.append("<code>&lt;length&gt;</code>")
+                    elif item['name'] == 'cssxref':
+                        assert len(item['args']) == 1
+                        bits.append("<code>{}</code>".format(item['args'][0]))
+                    else:
+                        self.issues.append(self.kumascript_issue(
+                            'unknown_kumascript', item, 'specdesc'))
+                elif item['type'] == 'code_block':
+                    bits.append("<code>{}</code>".format(item['content']))
+                else:
+                    assert item['type'] == 'text'
+                    bits.append(item['content'])
+
+        # Re-join the content
+        out = ""
+        nospace = '!,.;? '
+        for bit in bits:
+            if out and out[-1] not in nospace and bit[0] not in nospace:
+                out += " "
+            out += bit
+        return out
+
+    visit_specdesc_token = _visit_token
 
     def visit_inner_td(self, node, children):
         text = self.cleanup_whitespace(node.text)
@@ -417,6 +455,8 @@ class PageVisitor(NodeVisitor):
         return {
             'type': 'text', 'content': text,
             'start': node.start, 'end': node.end}
+
+    visit_spec_other = visit_inner_td
 
     #
     # Browser Compatibility section
@@ -643,11 +683,7 @@ class PageVisitor(NodeVisitor):
     # Browser Compatibility table cells
     #  Due to rowspan and colspan usage, we won't know if a cell is a feature
     #  or a support until visit_compat_body
-
-    def visit_compat_cell_item(self, node, children):
-        item = children[0]
-        assert isinstance(item, dict), type(item)
-        return item
+    visit_compat_cell_token = _visit_token
 
     def visit_cell_break(self, node, children):
         return {'type': 'break', 'start': node.start, 'end': node.end}

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1821,6 +1821,8 @@ def scrape_feature_page(feature_page):
     # Add issues
     for issue in scraped_data['issues']:
         feature_page.add_issue(issue, 'en-US')
+    merged_data['meta']['scrape']['issues'] = (
+        feature_page.data['meta']['scrape']['issues'])
 
     # Update status, issues
     has_data = (scraped_data['specs'] or scraped_data['compat'] or

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -717,14 +717,35 @@ class TestPageVisitor(ScrapeTestCase):
             ' <code>table-cell</code>.')
         self.assert_specdec_td(specdesc_td, expected, [])
 
-    def test_specdesc_td_unknown_kumascript(self):
-        specdesc_td = '<td>Baseline of {{HTMLElement("textarea")}}</td>'
-        expected = 'Baseline of'
+    def test_specdesc_td_kumascript_spec2(self):
+        # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
+        specdesc_td = "<td>No change from {{Spec2('HTML5 W3C')}}</td>"
+        expected = "No change from specification HTML5 W3C"
         issues = [
-            ('unknown_kumascript', 16, 43,
-             {'name': 'HTMLElement', 'args': ['textarea'],
-              'scope': 'specdesc',
-              'kumascript': '{{HTMLElement(textarea)}}'})]
+            ('specdesc_spec2_invalid', 19, 41,
+             {'name': 'Spec2', 'args': ['HTML5 W3C'], 'scope': 'specdesc',
+              'kumascript': '{{Spec2(HTML5 W3C)}}'})]
+        self.assert_specdec_td(specdesc_td, expected, issues)
+
+    def test_specdesc_td_kumascript_experimental_inline(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
+        specdesc_td = (
+            '<td>Defines <code>&lt;position&gt;</code> explicitly and extends'
+            ' it to support offsets from any edge. {{ experimental_inline() }}'
+            '</td>')
+        expected = (
+            'Defines <code>&lt;position&gt;</code> explicitly and extends'
+            ' it to support offsets from any edge.')
+        self.assert_specdec_td(specdesc_td, expected, [])
+
+    def test_specdesc_td_spec2(self):
+        # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
+        specdesc_td = "<td>No change from {{Spec2('HTML5 W3C')}}</td>"
+        expected = "No change from specification HTML5 W3C"
+        issues = [
+            ('specdesc_spec2_invalid', 19, 41,
+             {'name': 'Spec2', 'args': ['HTML5 W3C'], 'scope': 'specdesc',
+              'kumascript': '{{Spec2(HTML5 W3C)}}'})]
         self.assert_specdec_td(specdesc_td, expected, issues)
 
     def assert_compat_section(self, compat_section, compat, footnotes, issues):
@@ -1656,6 +1677,97 @@ class TestPageVisitor(ScrapeTestCase):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-zoom
         text = '"max-zoom" descriptor'
         self.assertEqual(text, self.visitor.unquote(text))
+
+    def assert_kumascript_to_text(
+            self, kumascript, expected_text, scope='specdesc', issues=None):
+        parsed = page_grammar['kumascript'].parse('{{' + kumascript + '}}')
+        item = self.visitor.visit(parsed)
+        text = self.visitor.kumascript_to_text(item, scope)
+        self.assertEqual(expected_text, text)
+        self.assertEqual(self.visitor.issues, issues or [])
+
+    def test_kumascript_to_text_xref_csslength(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
+        self.assert_kumascript_to_text(
+            'xref_csslength()', '<code>&lt;length&gt;</code>')
+
+    def test_kumascript_to_text_xref_csspercentage(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
+        self.assert_kumascript_to_text(
+            'xref_csspercentage()', '<code>&lt;percentage&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssstring(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/attr
+        self.assert_kumascript_to_text(
+            'xref_cssstring()', '<code>&lt;string&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssimage(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image
+        self.assert_kumascript_to_text(
+            'xref_cssimage()', '<code>&lt;image&gt;</code>')
+
+    def test_kumascript_to_text_xref_csscolorvalue(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/background-color
+        self.assert_kumascript_to_text(
+            'xref_csscolorvalue()', '<code>&lt;color&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssvisual(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/break-after
+        self.assert_kumascript_to_text('xref_cssvisual', '<code>visual</code>')
+
+    def test_kumascript_to_text_cssxref(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
+        self.assert_kumascript_to_text(
+            'cssxref("display")', '<code>display</code>')
+
+    def test_kumascript_to_text_domxref_1arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/CharacterData
+        self.assert_kumascript_to_text(
+            'domxref("ChildNode")', '<code>ChildNode</code>')
+
+    def test_kumascript_to_text_domxref_2arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent
+        self.assert_kumascript_to_text(
+            'domxref("CustomEvent.CustomEvent", "CustomEvent()")',
+            '<code>CustomEvent()</code>')
+
+    def test_kumascript_to_text_htmlelement(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/HTMLIsIndexElement
+        self.assert_kumascript_to_text(
+            'HTMLElement("isindex")', '<code>isindex</code>')
+
+    def test_kumascript_to_text_jsxref_1arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+        self.assert_kumascript_to_text(
+            'jsxref("Array.isArray")', '<code>Array.isArray</code>')
+
+    def test_kumascript_to_text_jsxref_2arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
+        self.assert_kumascript_to_text(
+            'jsxref("Global_Objects/null", "null")', '<code>null</code>')
+
+    def test_kumascript_to_text_specname(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/AbstractWorker
+        self.assert_kumascript_to_text(
+            'SpecName("Web Workers")', 'specification Web Workers')
+
+    def test_kumascript_to_text_unknown_kumascript(self):
+        issues = [
+            ('unknown_kumascript', 0, 23,
+             {'name': 'Unknown', 'args': ['textarea'],
+              'scope': 'specdesc',
+              'kumascript': '{{Unknown(textarea)}}'})]
+        self.assert_kumascript_to_text(
+            'Unknown("textarea")', None, issues=issues)
+
+    def assert_join_content(self, content_bits, expected_text):
+        text = self.visitor.join_content(content_bits)
+        self.assertEqual(expected_text, text)
+
+    def test_join_content_simple(self):
+        content_bits = ['Works', 'like', 'join.']
+        expected_text = 'Works like join.'
+        self.assert_join_content(content_bits, expected_text)
 
     def assert_browser_lookup(self, name, browser_id, fixed_name, slug):
         lookup = self.visitor.browser_id_name_and_slug(name)

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -128,7 +128,7 @@ class TestFetchMetaTask(TestCase):
         meta = fp.meta()
         issues = [[
             'failed_download', 0, 0,
-            {'url': meta.url(), 'status': 404, 'content': 'Not Found'}]]
+            {'url': meta.url(), 'status': 404, 'content': 'Not Found'}, None]]
         self.assertEqual(issues, fp.data['meta']['scrape']['issues'])
         self.assertEqual(meta.STATUS_ERROR, meta.status)
         self.assertEqual('Status 404, Content:\nNot Found', meta.raw)
@@ -142,7 +142,8 @@ class TestFetchMetaTask(TestCase):
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_ERROR, fp.status)
         issues = [[
-            'bad_json', 0, 0, {'url': fp.url + '$json', 'content': text}]]
+            'bad_json', 0, 0,
+            {'url': fp.url + '$json', 'content': text}, None]]
         self.assertEqual(issues, fp.data['meta']['scrape']['issues'])
         meta = fp.meta()
         self.assertEqual(meta.STATUS_ERROR, meta.status)
@@ -315,7 +316,7 @@ class TestFetchTranslationTask(TestCase):
         url = trans.url() + '?raw'
         issue = [[
             'failed_download', 0, 0,
-            {'url': url, 'status': 404, 'content': content}]]
+            {'url': url, 'status': 404, 'content': content}, None]]
         self.assertEqual(issue, fp.data['meta']['scrape']['issues'])
 
 

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -153,7 +153,6 @@ class FeaturePageReParse(UpdateView):
         redirect = super(FeaturePageReParse, self).form_valid(form)
         assert self.object and self.object.id
         self.object.status = FeaturePage.STATUS_PARSING
-        self.object.issues.all().delete()
         self.object.reset_data()
         self.object.save()
         messages.add_message(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,14 +12,14 @@ docutils==0.12
 # Multi-environment testing
 py==1.4.27
 pluggy==0.3.0
-virtualenv==12.1.1
+virtualenv==13.0.1
 tox==2.0.1
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3
 pep8==1.5.7  # rq.filter: <1.6,>=1.5.7
 pyflakes==0.8.1
-flake8==2.4.0
+flake8==2.4.1
 pep257==0.5.0
 flake8-docstrings==0.2.1.post1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,15 +41,14 @@ gunicorn==19.3.0
 psycopg2==2.6
 
 # Serve static files
-# static3 0.6.0 has utf-8 issue
-git+git://github.com/ryanhiebert/static3@tox-fix#egg=static3
+static3==0.6.1
 dj-static==0.0.6
 
 # Timezone info
 pytz==2015.4
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
-pylibmc==1.4.2
+pylibmc==1.4.3
 django-pylibmc==0.6.0
 django-pylibmc-sasl==0.2.4
 
@@ -64,13 +63,14 @@ celery==3.1.18
 django-mptt==0.7.3
 
 # Sorted ManyToManyField
-django-sortedm2m==0.9.5
+django-sortedm2m==0.10.0
 
 # Cached instances for Django REST Framework
 drf-cached-instances==0.3.0
 
 # CORS headers in middleware
-# Head includes PR #51, waiting for release
+# django-cors-headers==1.1.0
+# Bug #50 (fixed by PR #51) prevents Firefox CORS
 git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
@@ -84,4 +84,4 @@ git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 requests==2.7.0
 oauthlib==0.7.2
 requests-oauthlib==0.5.0
-django-allauth==0.19.1
+django-allauth==0.20.0

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -101,7 +101,7 @@ class GatherImportIssues(Tool):
             issues = resp_json['meta']['scrape']['issues']
             for issue in issues:
                 assert isinstance(issue, list)
-                issue_slug, start_pos, end_pos, raw_params = issue
+                issue_slug, start_pos, end_pos, raw_params = issue[:4]
                 params = dumps(raw_params)
                 issue_rows.append(
                     (mdn_slug, human_import_url, issue_slug, start_pos,

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -38,8 +38,8 @@ class TestMixin(object):
             groups = ['change-resource']
         group_list = [Group.objects.get(name=g) for g in groups]
         user.groups.add(*group_list)
-        if 'change-resource' not in groups:
-            user.groups.remove(Group.objects.get(name='change-resource'))
+        # In some removed tests, had to remove the default
+        assert 'change-resource' in groups
         self.assertTrue(
             self.client.login(username=username, password=password))
         self.user = user


### PR DESCRIPTION
*This builds on PR #32, and can be rebased*

Tokenize the specification description (column 3), so that KumaScript macros can be analyzed and replaced with plain HTML versions.  Added handlers for KS currently in use on MDN.  Translated version does not include cross referencing to MDN pages.  New issue `specdesc_spec2_invalid` for when an author used `{{Spec2}}` but probably meant `{{SpecName}}`.

Also:
- Bump requirements to latest
- Mirror issues in the scrape JSON, so that no database access is needed to get issue counts.  Speeds up imports by 30%, gathering issues by 90%.

Issues decreased from 6298 to 6283, but there may be fixes occurring on MDN.  New counts after re-parsing:

Issue | Count Before | Count After
-----|----|----|
section_skipped | 2041 | 2260
inline_text | 1441 | 1343
halt_import | 428 | 419
doc_parse_error | 408 | 408
unknown_kumascript | 306 | 263
footnote_no_id | 305 | 297
unexpected_attribute | 292 | 280
spec2_converted | 255 | 228
specname_converted | 188 | 182
unknown_version | 150 | 141
footnote_missing | 137 | 135
specname_not_kumascript | 87 | 66
footnote_multiple | 40 | 36
spec_h2_id | 38 | 38
spec_mismatch | 32 | 31
spec_h2_name | 32 | 32
section_missed | 29 | 37
unknown_spec | 24 | 24
footnote_unused | 22 | 17
unknown_browser | 18 | 18
compatgeckodesktop_unknown | 8 | 8
specdec_spec2_invalid | (n/a) | 5
spec2_arg_count | 5 | 5
specname_blank_key | 4 | 4
spec2_wrong_kumascript | 4 | 4
footnote_feature | 3 | 2