### PR TITLE
Fix bug 1139619 and 1134450 - Better parsing of footnotes

### DIFF
--- a/mdn/models.py
+++ b/mdn/models.py
@@ -514,6 +514,8 @@ class Issue(models.Model):
             return ''
 
         raw = self.content.raw
+        if not raw.endswith('\n'):
+            raw += '\n'
         start_line = raw.count('\n', 0, self.start)
         end_line = raw.count('\n', 0, self.end)
         ctx_start_line = max(0, start_line - 2)
@@ -539,7 +541,7 @@ class Issue(models.Model):
 
         out = []
         for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
-            lnum = ctx_start_line + num
+            lnum = ctx_start_line + num + 1
             out.append(
                 text_type(lnum).rjust(digits) + ' ' + line)
             if '^' in err_line:

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -377,6 +377,16 @@ ISSUES = OrderedDict((
         ERROR,
         'Nested <p> tags are not supported.',
         'Edit the MDN page to remove the nested <p> tag')),
+    ('missing_attribute', (
+        ERROR,
+        'The tag <{node_type}> is missing the expected attribute {ident}',
+        'Add the missing attribute or convert the tag to plain text.')),
+    ('second_footnote', (
+        ERROR,
+        'An additional footnote was detected in content',
+        'The footnote [{original}] is being used, and the footnote [{new}]'
+        ' discarded.  If footnotes are in the same <p> and split by <br>'
+        ' tags, then split into paragraphs to fix.')),
     ('section_skipped', (
         CRITICAL,
         'Section <h2>{title}</h2> has unexpected content.',
@@ -391,6 +401,12 @@ ISSUES = OrderedDict((
         'The import of section {title} failed, but no parse error was'
         ' detected. This is usually because of a previous critical error,'
         ' which must be cleared before any parsing can be attempted.')),
+    ('skipped_h3', (
+        WARNING,
+        '<h3>{h3}</h3> was not imported.',
+        '<h3> subsections are usually prose compatibility information, and'
+        ' anything after an <h3> is not parsed or imported. Convert to'
+        ' footnotes or move to a different <h2> section.')),
     ('spec_h2_id', (
         WARNING,
         'Expected <h2 id="Specifications">, actual id={h2_id}',
@@ -437,6 +453,12 @@ ISSUES = OrderedDict((
         ERROR,
         '{kumascript} is invalid in the spec description',
         'Handled as if {{{{SpecName(...)}}}} was used. Update the MDN page.')),
+    ('tag_dropped', (
+        WARNING,
+        'HTML element {tag} (but not wrapped content) was removed.',
+        'The element {tag} is not allowed in the {scope} scope, and was'
+        ' removed. You can remove the tag from the MDN page to remove the'
+        ' warning.')),
     ('unexpected_attribute', (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -440,8 +440,8 @@ ISSUES = OrderedDict((
     ('unexpected_attribute', (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',
-        'For <{node_type}>, the importer is ready for the attributes'
-        ' {expected}. This unexpected attribute will be discarded.')),
+        'For <{node_type}>, the importer expects {expected}. This unexpected'
+        ' attribute will be discarded.')),
     ('unknown_browser', (
         ERROR,
         'Unknown Browser "{name}".',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -229,7 +229,7 @@ class FeaturePage(models.Model):
             issues = raw.get('issues', [])
         for issue in issues:
             slug = issue[0]
-            severity = ISSUES[slug][0]
+            severity = ISSUES.get(slug, UNKNOWN_ISSUE)[0]
             counts[severity] += 1
         return counts
 
@@ -470,6 +470,9 @@ ISSUES = OrderedDict((
         ' be added to the API.')),
 ))
 
+UNKNOWN_ISSUE = (
+    CRITICAL, 'Unknown Issue', "This issue slug doesn't have a description.")
+
 
 @python_2_unicode_compatible
 class Issue(models.Model):
@@ -498,15 +501,15 @@ class Issue(models.Model):
 
     @property
     def severity(self):
-        return ISSUES[self.slug][0]
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[0]
 
     @property
     def brief_description(self):
-        return ISSUES[self.slug][1].format(**self.params)
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[1].format(**self.params)
 
     @property
     def long_description(self):
-        return ISSUES[self.slug][2].format(**self.params)
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[2].format(**self.params)
 
     @property
     def context(self):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -775,20 +775,8 @@ class PageVisitor(NodeVisitor):
                             bits.append(text)
                     else:
                         assert item_type == 'pre'
-                        allowed = {
-                            'class': ['brush:css'],
-                        }
-                        attrs = []
-                        for name, vitem in item['attributes'].items():
-                            assert name in allowed
-                            value = vitem['value']
-                            assert value in allowed[name]
-                            attrs.append((name, value))
-                        attrs.sort()
-                        attr_out = " ".join('%s="%s"' % a for a in attrs)
-                        attr_space = ' ' if attr_out else ''
-                        bits.append('<pre{}{}>{}</pre>'.format(
-                            attr_space, attr_out, item['content']))
+                        out = self._consume_attributes(item, [])
+                        bits.append('<pre>{}</pre>'.format(out['content']))
                 line = self.join_content(bits)
                 if line:
                     if include_p and wrap_p:
@@ -918,8 +906,14 @@ class PageVisitor(NodeVisitor):
                 assert ident not in node_out
                 node_out[ident] = attr['value']
             else:
-                expected_text = (
-                    ', '.join(expected[:-1]) + ' or ' + expected[-1])
+                if len(expected) > 1:
+                    expected_text = (
+                        'the attributes ' + ', '.join(expected[:-1]) + ' or ' +
+                        expected[-1])
+                elif len(expected) == 1:
+                    expected_text = 'the attribute ' + expected[0]
+                else:
+                    expected_text = 'no attributes'
                 self.issues.append((
                     'unexpected_attribute', attr['start'], attr['end'],
                     {'node_type': node_dict['type'], 'ident': ident,

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -422,7 +422,7 @@ class PageVisitor(NodeVisitor):
             assert isinstance(specdesc, list), type(specdesc)
             for item in specdesc:
                 if item['type'] == 'kumascript':
-                    text = self.kumascript_to_text(item, 'specdesc')
+                    text = self.kumascript_to_html(item, 'specdesc')
                     if text:
                         bits.append(text)
                 elif item['type'] == 'code':
@@ -764,7 +764,7 @@ class PageVisitor(NodeVisitor):
                     elif item_type == 'text':
                         bits.append(item['content'])
                     elif item_type == 'kumascript':
-                        text = self.kumascript_to_text(item, 'footnote')
+                        text = self.kumascript_to_html(item, 'footnote')
                         if text:
                             bits.append(text)
                     else:
@@ -1014,8 +1014,8 @@ class PageVisitor(NodeVisitor):
             {'name': item['name'], 'args': item['args'], 'scope': scope,
              'kumascript': "{{%s%s}}" % (item['name'], args)})
 
-    def kumascript_to_text(self, item, scope):
-        """Convert kumascript to plain text."""
+    def kumascript_to_html(self, item, scope):
+        """Convert kumascript to plain HTML."""
         assert item['type'] == 'kumascript'
         name = item['name']
         args = item['args']

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -233,15 +233,26 @@ Enjoy.
         self.issue.start = content.find('ERROR')
         self.issue.end = self.issue.start + len('ERROR')
         expected = """\
-0 Here's the error:
-1 ---> ERROR <-----
+1 Here's the error:
+2 ---> ERROR <-----
 *      ^^^^^       \n\
-2 Enjoy."""
+3 Enjoy."""
         self.assertEqual(expected, self.issue.context)
 
     def test_context_without_content(self):
         self.issue.content = None
         self.assertEqual("", self.issue.context)
+
+    def test_context_end_of_page(self):
+        content = "Line1\nLine2"
+        self.en_content.raw = content
+        self.issue.start = content.find('Line2')
+        self.issue.end = self.issue.start + len('Line')
+        expected = """\
+1 Line1
+2 Line2
+* ^^^^ """
+        self.assertEqual(expected, self.issue.context)
 
 
 class TestPageMetaModel(TestCase):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -971,8 +971,8 @@ class TestPageVisitor(ScrapeTestCase):
         row_cell = '<td><code>canonical</code></td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},
-            {'type': 'code_block', 'content': 'canonical', 'start': 4,
-             'end': 26},
+            {'type': 'code', 'content': 'canonical', 'attributes': {},
+             'start': 4, 'end': 26},
         ]
         self.assert_compat_row_cell(row_cell, expected_cell, [])
 
@@ -1586,7 +1586,7 @@ class TestPageVisitor(ScrapeTestCase):
                 ".foo {background-image: url(bg-image.png);}\n</pre>",
                 0, 103)}
         issues = [
-            ('unexpected_attribute', 33, 51,
+            ('unexpected_attribute', 34, 51,
              {'ident': 'class', 'node_type': 'pre', 'value': 'brush:css',
               'expected': 'no attributes'})]
         self.assert_compat_footnotes(footnotes, expected, issues)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1583,6 +1583,31 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [('footnote_no_id', 0, 18, {})]
         self.assert_compat_footnotes(footnotes, {}, issues)
 
+    def test_compat_footnotes_empty_paragraph_no_footnotes(self):
+        footnotes = ('<p>  </p>\n')
+        self.assert_compat_footnotes(footnotes, {}, [])
+
+    def test_compat_footnotes_empty_paragraph_invalid_footnote(self):
+        footnotes = (
+            '<p> </p>\n'
+            '<p>Invalid footnote.</p>\n'
+            '<p>  </p>')
+        issues = [('footnote_no_id', 9, 34, {})]
+        self.assert_compat_footnotes(footnotes, {}, issues)
+        self.assertEqual(footnotes[9:34], '<p>Invalid footnote.</p>\n')
+
+    def test_compat_footnotes_empty_paragraphs_trimmed(self):
+        footnote = (
+            '<p> </p>\n'
+            '<p>[1] Valid footnote.</p>'
+            '<p>   </p>'
+            '<p>Continues footnote 1.</p>')
+        expected = {
+            '1': (
+                '<p>Valid footnote.</p>\n<p>Continues footnote 1.</p>',
+                9, 73)}
+        self.assert_compat_footnotes(footnote, expected, [])
+
     def assert_kumascript(self, text, name, args, issues=None):
         parsed = page_grammar['kumascript'].parse(text)
         expected = {

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1731,86 +1731,86 @@ class TestPageVisitor(ScrapeTestCase):
         text = '"max-zoom" descriptor'
         self.assertEqual(text, self.visitor.unquote(text))
 
-    def assert_kumascript_to_text(
+    def assert_kumascript_to_html(
             self, kumascript, expected_text, scope='specdesc', issues=None):
         parsed = page_grammar['kumascript'].parse('{{' + kumascript + '}}')
         item = self.visitor.visit(parsed)
-        text = self.visitor.kumascript_to_text(item, scope)
+        text = self.visitor.kumascript_to_html(item, scope)
         self.assertEqual(expected_text, text)
         self.assertEqual(self.visitor.issues, issues or [])
 
-    def test_kumascript_to_text_xref_csslength(self):
+    def test_kumascript_to_html_xref_csslength(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csslength()', '<code>&lt;length&gt;</code>')
 
-    def test_kumascript_to_text_xref_csspercentage(self):
+    def test_kumascript_to_html_xref_csspercentage(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csspercentage()', '<code>&lt;percentage&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssstring(self):
+    def test_kumascript_to_html_xref_cssstring(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/attr
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_cssstring()', '<code>&lt;string&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssimage(self):
+    def test_kumascript_to_html_xref_cssimage(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_cssimage()', '<code>&lt;image&gt;</code>')
 
-    def test_kumascript_to_text_xref_csscolorvalue(self):
+    def test_kumascript_to_html_xref_csscolorvalue(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/background-color
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csscolorvalue()', '<code>&lt;color&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssvisual(self):
+    def test_kumascript_to_html_xref_cssvisual(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/break-after
-        self.assert_kumascript_to_text('xref_cssvisual', '<code>visual</code>')
+        self.assert_kumascript_to_html('xref_cssvisual', '<code>visual</code>')
 
-    def test_kumascript_to_text_cssxref(self):
+    def test_kumascript_to_html_cssxref(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'cssxref("display")', '<code>display</code>')
 
-    def test_kumascript_to_text_domxref_1arg(self):
+    def test_kumascript_to_html_domxref_1arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/CharacterData
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'domxref("ChildNode")', '<code>ChildNode</code>')
 
-    def test_kumascript_to_text_domxref_2arg(self):
+    def test_kumascript_to_html_domxref_2arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'domxref("CustomEvent.CustomEvent", "CustomEvent()")',
             '<code>CustomEvent()</code>')
 
-    def test_kumascript_to_text_htmlelement(self):
+    def test_kumascript_to_html_htmlelement(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/HTMLIsIndexElement
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'HTMLElement("isindex")', '<code>isindex</code>')
 
-    def test_kumascript_to_text_jsxref_1arg(self):
+    def test_kumascript_to_html_jsxref_1arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'jsxref("Array.isArray")', '<code>Array.isArray</code>')
 
-    def test_kumascript_to_text_jsxref_2arg(self):
+    def test_kumascript_to_html_jsxref_2arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'jsxref("Global_Objects/null", "null")', '<code>null</code>')
 
-    def test_kumascript_to_text_specname(self):
+    def test_kumascript_to_html_specname(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/AbstractWorker
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'SpecName("Web Workers")', 'specification Web Workers')
 
-    def test_kumascript_to_text_unknown_kumascript(self):
+    def test_kumascript_to_html_unknown_kumascript(self):
         issues = [
             ('unknown_kumascript', 0, 23,
              {'name': 'Unknown', 'args': ['textarea'],
               'scope': 'specdesc',
               'kumascript': '{{Unknown(textarea)}}'})]
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'Unknown("textarea")', None, issues=issues)
 
     def assert_join_content(self, content_bits, expected_text):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1626,6 +1626,16 @@ class TestPageVisitor(ScrapeTestCase):
                 9, 73)}
         self.assert_compat_footnotes(footnote, expected, [])
 
+    def test_compat_footnotes_code(self):
+        footnote = (
+            '<p>[1] From Firefox 31 to 35, <code>will-change</code>'
+            ' was available...</p>')
+        expected = {
+            '1': (
+                'From Firefox 31 to 35, <code>will-change</code>'
+                ' was available...', 0, 75)}
+        self.assert_compat_footnotes(footnote, expected, [])
+
     def assert_kumascript(self, text, name, args, issues=None):
         parsed = page_grammar['kumascript'].parse(text)
         expected = {

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -932,7 +932,7 @@ class TestPageVisitor(ScrapeTestCase):
              'expected': 'rowspan or colspan'})]
         self.assert_compat_row_cell(row_cell, expected_cell, issues)
 
-    def test_compat_row_cell_break(self):
+    def test_compat_row_break(self):
         row_cell = '<td>Multi-line<br/>feature</td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},
@@ -953,7 +953,7 @@ class TestPageVisitor(ScrapeTestCase):
         ]
         self.assert_compat_row_cell(row_cell, expected_cell, [])
 
-    def test_compat_row_cell_code_block(self):
+    def test_compat_row_code_block(self):
         row_cell = '<td><code>canonical</code></td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1538,20 +1538,20 @@ class TestPageVisitor(ScrapeTestCase):
     def test_compat_footnotes_unknown_kumascriptscript(self):
         footnotes = (
             "<p>[1] Footnote {{UnknownKuma}} but the beat continues.</p>")
-        expected = {'1': ('Footnote  but the beat continues.', 0, 59)}
+        expected = {'1': ('Footnote but the beat continues.', 0, 59)}
         issues = [(
-            'unknown_kumascript', 15, 30,
+            'unknown_kumascript', 16, 32,
             {'name': 'UnknownKuma', 'args': [], 'scope': 'footnote',
              'kumascript': '{{UnknownKuma}}'})]
         self.assert_compat_footnotes(footnotes, expected, issues)
 
     def test_compat_footnotes_unknown_kumascriptscript_with_args(self):
         footnotes = '<p>[1] Footnote {{UnknownKuma("arg")}}</p>'
-        expected = {'1': ('Footnote ', 0, 42)}
+        expected = {'1': ('Footnote', 0, 42)}
         issues = [(
-            'unknown_kumascript', 15, 37,
-            {'name': 'UnknownKuma', 'args': ['"arg"'], 'scope': 'footnote',
-             'kumascript': '{{UnknownKuma("arg")}}'})]
+            'unknown_kumascript', 16, 38,
+            {'name': 'UnknownKuma', 'args': ['arg'], 'scope': 'footnote',
+             'kumascript': '{{UnknownKuma(arg)}}'})]
         self.assert_compat_footnotes(footnotes, expected, issues)
 
     def test_compat_footnotes_pre_section(self):


### PR DESCRIPTION
*Builds on previous PRs, will rebase after merging.*

Switch from parsing footnotes as a list of tokens to a hierarchy of HTML elements.  

Adds some parse issues:
- `missing_attribute` - An element is missing a required tag (a requires href)
- `second_footnote` - A second footnote ID (like [2]) was found in the footnote
- `skipped_h3` - An h3 section was found in the Specification section, and ignored
- `tag_dropped` - A tag, such as span, was dropped from the parsed data

Tests pass w/ 100% coverage, but the code could be further improved.  Opened [bug 1171957](https://bugzilla.mozilla.org/show_bug.cgi?id=1171957) to cover work on refactoring code.

Issue counts were affected by the change:

        Issue Slug         | Old Count | New Count
---------------------------|-----------|----------
**Total**                  |      6245 |      7172
section_skipped            |      2256 |      2200
inline_text                |      1334 |      1946
halt_import                |       412 |       155
doc_parse_error            |       405 |       405
footnote_no_id             |       296 |        75
unexpected_attribute       |       280 |       483
unknown_kumascript         |       265 |       274
spec2_converted            |       229 |       284
specname_converted         |       181 |       194
unknown_version            |       141 |       220
footnote_missing           |       135 |       106
specname_not_kumascript    |        68 |       110
spec_h2_id                 |        38 |        38
section_missed             |        37 |        40
footnote_multiple          |        36 |        36
spec_h2_name               |        32 |        32
spec_mismatch              |        31 |        31
unknown_spec               |        24 |        24
unknown_browser            |        18 |        43
footnote_unused            |        17 |        57
compatgeckodesktop_unknown |         8 |        10
footnote_feature           |         2 |         2
missing_attribute          |         0 |        98
tag_dropped                |         0 |        22
skipped_h3                 |         0 |       262
span_dropped               |         0 |        12
spec2_wrong_kumascript     |         0 |         1
second_footnote            |         0 |        12