### PR TITLE
fix bug 1170196 - Filter issues by topic, other fixes

### DIFF
--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -6,6 +6,7 @@ This file is loaded by jingo and must be named helpers.py
 from jinja2 import contextfunction, Markup
 from jingo import register
 
+from webplatformcompat.helpers import add_query_param
 from .views import can_create, can_refresh
 
 
@@ -58,7 +59,7 @@ def pagination_control(context, page_obj, url):
         if prev_page == 1:
             prev_url = url
         else:
-            prev_url = url + '?page=%d' % prev_page
+            prev_url = add_query_param(url, page=prev_page)
         previous_nav = (
             '<li><a href="{prev_url}" aria-label="Previous">'
             '<span aria-hidden="true">&laquo;</span></a></li>'
@@ -82,21 +83,22 @@ def pagination_control(context, page_obj, url):
         else:
             active = ''
         if page == 1:
-            page_query = ''
+            page_url = url
         else:
-            page_query = "?page=%d" % page
+            page_url = add_query_param(url, page=page)
         page_navs.append(
-            '<li{active}><a href="{url}{page_query}">'
+            '<li{active}><a href="{page_url}">'
             '{page}</a></li>'.format(
-                active=active, url=url, page_query=page_query, page=page))
+                active=active, url=url, page_url=page_url, page=page))
     page_nav = "\n    ".join(page_navs)
 
     if page_obj.has_next():
+        next_url = add_query_param(url, page=page_obj.next_page_number())
         next_nav = """<li>
-      <a href="{url}?page={page}" aria-label="Next">
+      <a href="{next_url}" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
       </a>
-    </li>""".format(url=url, page=page_obj.next_page_number())
+    </li>""".format(next_url=next_url)
     else:
         next_nav = """\
     <li class="disabled"><span aria-hidden="true">&raquo;</span></li>"""

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -1,4 +1,5 @@
 {% extends "webplatformcompat/base.jinja2" %}
+{% import "mdn/macros.jinja2" as macros %}
 
 {% block head_title %}Parse results for {{ object.slug() }}{% endblock %}
 {% block body_title %}Parse results for {{ object.slug() }}{% endblock %}
@@ -27,22 +28,9 @@
   <dt>Issues</dt>
     <dd>{% if object.has_issues %}
       <ol>
-        {% for issue in object.issues.order_by("start") %}
-        <li><div>
-            <p>
-                <strong>{{ issue.get_severity_display() }}: {{ issue.brief_description }}</strong><br/>
-                {{ issue.long_description }}<br>
-                <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{ issue.slug }}">More information about issue "{{ issue.slug }}"</a>
-            </p>
-            {% if issue.params.rule %}
-            <p><em>Parser rule:</em></p>
-            <p><code>{{ issue.params.rule }}</code></p>
-            {% endif %}
-            {% if issue.content %}
-            <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
-            {% endif %}
-        </div></li>
-        {% endfor %}
+        {% for issue in object.issues.order_by("start") -%}
+        <li>{{ macros.issue_div(issue) }}</li>
+        {% endfor -%}
       </ol>{% else %}
       <em>None detected</em>
       {% endif %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -46,7 +46,7 @@
     ({{ page_obj.paginator.count }}
     import{% if page_obj.paginator.count > 1 %}s{% endif %})
 </h3>
-{{ pagination_control(page_obj, url('feature_page_list')) }}
+{{ pagination_control(page_obj, base_url) }}
 <table class="table table-condensed">
   <thead>
     <tr>
@@ -87,7 +87,7 @@
     {% endfor %}
   </tbody>
 </table>
-{{ pagination_control(page_obj, url('feature_page_list')) }}
+{{ pagination_control(page_obj, base_url) }}
 {% else %}
 <p><i>No pages imported yet.</i></p>
 {% endif %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -16,25 +16,54 @@
     <input type="url" class="form-control" id="id-url" name="url"
      placeholder="https://developer.mozilla.org/en-US/docs/...">
   </div>
-  <input id="fp-search" class="btn btn-primary" type="submit" value="Search by URL">
+  <input id="fp-search" class="btn btn-primary" type="submit"
+   value="Search or Filter by URL">
 </form>
+
+<h3>Filter by Topic </h3>
+<div>
+{% for topic_name in topics %}
+{% if topic == topic_name %}
+<a class="btn btn-primary"
+   href="{{ url('feature_page_list') }}">
+  {{ topic_name }} (clear)
+</a>
+{% else %}
+<a class="btn btn-default"
+   href="{{ url('feature_page_list') + '?topic=' + topic_name }}">
+  {{ topic_name }}
+</a>
+{% endif %}
+{% endfor %}
+{% if topic and topic not in topics %}
+<a class="btn btn-primary">{{ topic }} (clear)</a>
+{% endif %}
+</div>
+
 {% if page_obj %}
+<h3>
+    Import Results
+    ({{ page_obj.paginator.count }}
+    import{% if page_obj.paginator.count > 1 %}s{% endif %})
+</h3>
 {{ pagination_control(page_obj, url('feature_page_list')) }}
 <table class="table table-condensed">
   <thead>
     <tr>
-      <th>#</th>
-      <th>Feature ID</th>
       <th>MDN Slug</th>
       <th>Status</th>
-      <th>Warnings /<br/>Errors /<br/>Critical Errors</th>
+      <th>
+        <span id="issue-header"
+              data-toggle="tooltip" data-placement="top"
+              title="Warnings / Errors / Critical Errors">
+          Issues
+        </span>
+      </th>
     </tr>
   </thead>
   <tbody>
     {% for page in page_obj.object_list %}
     <tr>
-      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{ page.id }}</a></td>
-      <td>{{ page.feature_id }}</td>
       <td>{{ page.slug() }}</td>
       <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{ page.get_status_display() }}</a></td>
       <td>
@@ -68,3 +97,11 @@
 {% endif %}
 
 {% endblock content %}
+
+{% block block_js_extra %}
+<script>
+$(function () {
+  $('#issue-header').tooltip()
+})
+</script>
+{% endblock %}

--- a/mdn/templates/mdn/issues_detail.jinja2
+++ b/mdn/templates/mdn/issues_detail.jinja2
@@ -1,0 +1,46 @@
+{% extends "webplatformcompat/base.jinja2" %}
+{% import "mdn/macros.jinja2" as macros %}
+
+{% macro title() -%}
+    MDN Importer issue <code>{{slug}}</code>
+    {% if count %}
+    {% endif %}
+{%- endmacro %}
+
+{% block head_title %}{{title()}}{% endblock %}
+{% block body_title %}{{title()}}{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to
+    <a href="{{ url('issues_summary') }}">issues summary</a>, or the
+    <a href="{{ url('feature_page_list') }}">list of imported pages</a></em></p>
+{% endblock %}
+
+{% block content %}
+{% if count %}
+<p>
+    There are
+    {{count}} count{% if count != 1%}s{% endif %} of this issue
+    on {{pages | length}} page{% if pages | length > 1 %}s{% endif %}.
+<p>
+<h3>Sample</h3>
+<p>
+    Here's a sample from the import of
+    <a href="{{url('feature_page_detail', pk=sample_issue.page_id)}}">
+      {{sample_issue.page.slug()}}</a>:
+</p>
+<p>{{ macros.issue_div(sample_issue) }}</p>
+<h3>Imports with this issue</h3>
+<p>Here's the full list of imports where this issue was found:<p>
+<ul>
+{% for key, page_count in pages | dictsort -%}
+<li>
+    {{page_count}} in
+    <a href="{{url('feature_page_detail', pk=key[1])}}">{{key[0]}}</a>
+</li>
+{%- endfor %}
+</ul>
+{% else %}
+<p>There are no pages with this issue.</p>
+{% endif %}
+{% endblock content %}

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -12,12 +12,17 @@
 <ul>
 {% for count, slug, severity, brief, examples in issues %}
   {% if count > 0 %}
-  <li>{{count}} count{% if count > 1 %}s{% endif %} of
-      <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}"><code>{{slug}}</code></a>
-      ({{severity}}): {{brief}}  Example{% if count != 0 %}s{% endif %}:
+  <li>
+    <a href="{{url('issues_detail', slug=slug)}}">
+      {{count}} count{% if count > 1 %}s{% endif %}</a>
+    of
+    <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}">
+      <code>{{slug}}</code></a>
+    ({{severity}})
+    Example{% if count != 0 %}s{% endif %}:
     <ul>
-      {% for pk, mdn_url in examples %}
-      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>
+      {% for mdn_path, pk in examples %}
+      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_path}}</a></li>
       {% endfor %}
     </ul>
   </li>

--- a/mdn/templates/mdn/macros.jinja2
+++ b/mdn/templates/mdn/macros.jinja2
@@ -1,0 +1,20 @@
+{% macro issue_div(issue) -%}
+<div>
+  <p>
+    <strong>{{issue.get_severity_display()}}: {{issue.brief_description}}</strong>
+    <br>
+    {{issue.long_description}}
+    <br>
+    <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{issue.slug}}">
+      More information about issue "{{issue.slug}}"
+    </a>
+  </p>
+{% if issue.params.get('rule') %}
+  <p><em>Parser rule:</em></p>
+  <p><code>{{ issue.params['rule'] }}</code></p>
+{% endif %}
+{% if issue.content %}
+  <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
+{% endif %}
+</div>
+{%- endmacro %}

--- a/mdn/urls.py
+++ b/mdn/urls.py
@@ -7,6 +7,7 @@ mdn_urlpatterns = patterns(
     url(r'^create$', 'feature_page_create', name='feature_page_create'),
     url(r'^search$', 'feature_page_search', name='feature_page_search'),
     url(r'^issues$', 'issues_summary', name='issues_summary'),
+    url(r'^issues/(?P<slug>.*)$', 'issues_detail', name='issues_detail'),
     url(r'^(?P<pk>\d+)$', 'feature_page_detail', name='feature_page_detail'),
     url(r'^(?P<pk>\d+)\.json$', 'feature_page_json', name='feature_page_json'),
     url(r'^(?P<pk>\d+)/reset$', 'feature_page_reset',

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -38,8 +38,13 @@ class FeaturePageListView(ListView):
 
     def get_context_data(self, **kwargs):
         ctx = super(FeaturePageListView, self).get_context_data(**kwargs)
+        topic = self.request.GET.get('topic')
+        base_url = reverse('feature_page_list')
+        if topic:
+            base_url += '?topic=' + topic
+        ctx['base_url'] = base_url
         ctx['request'] = self.request
-        ctx['topic'] = self.request.GET.get('topic')
+        ctx['topic'] = topic
         ctx['topics'] = sorted((
             'Web/API',
             'Web/Accessibility',

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -391,6 +391,13 @@ Browse.Properties = {
                 i,
                 keyLen;
             if (!property) { return []; }
+            if (typeof property === 'string') {
+                outArray.push({
+                    'lang': 'canonical',
+                    'value': '<code>' + property + '</code>'
+                });
+                return outArray;
+            }
             for (key in property) {
                 if (property.hasOwnProperty(key)) {
                     if (key === 'en') {
@@ -419,6 +426,10 @@ Browse.Properties = {
                 i,
                 val;
             if (arrayLen === 0) { return '<em>none</em>'; }
+            if (arrayLen === 1 && array[0].lang === 'canonical') {
+                ul = array[0].value;
+                return ul;
+            }
             for (i = 0; i < arrayLen; i += 1) {
                 item = array[i];
                 val = item.value;

--- a/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
@@ -114,12 +114,17 @@ function load_tables(resources, lang) {
 
 function load_json(uri) {
     $.getJSON(uri).done(function( data ) {
-        var resources, json_dump, title;
+        var resources, json_dump, title, name;
         json_dump = $("<pre>").text(JSON.stringify(data, null, "  "));
         $("#wpc_data").html(json_dump);
         window.resources = resources = WPC.parse_resources(data);
 
-        title = "Sample View for Feature '" + resources.data.name.en + "'";
+        name = WPC.trans_str(resources.data.name, 'en');
+        if (name.indexOf("<code>") === 0) {
+            title = "Sample View for Feature " + name;
+        } else {
+            title = "Sample View for Feature '" + name + "'";
+        }
         document.title = title;
         $("#body_title").html(title);
 


### PR DESCRIPTION
`This PR builds on previous PRs, and can be rebased`.

Importer pages can be filtered by "topic", such as "Web/API" for https://developer.mozilla.org/en-US/docs/Web/API and all the pages under that path, such as https://developer.mozilla.org/en-US/docs/Web/API/AbstractWorker and https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent .  The mechanism is a query string parameter, such as https://browsercompat.herokuapp.com/importer/?topic=Web/API .  The list view has been updated to emphasize topics.

This PR also fixes some issues with displaying features with canonical names, and adds an endpoint for seeing all the pages affected by a particular issue.

The code is live on the test server: https://browsercompat.herokuapp.com/importer/