### PR TITLE
Fix bug 1138455 - Support 'no prefix' and 'partial' inline text

### DIFF
--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -223,11 +223,14 @@ tr_tags = tr_tag*
 # Text segments
 #
 text_block = text_token+
-text_token = kumascript / cell_version / footnote_id / cell_removed / text_item
+text_token = kumascript / cell_version / footnote_id / cell_removed /
+    cell_noprefix / text_item
 cell_version = ~r"(?P<version>\d+(\.\d+)*)"""
     r"""(\s+\((?P<eng_version>\d+(\.\d+)*)\))?\s*"s
 footnote_id = "[" ~r"(?P<content>\d+|\*+)" "]"
 cell_removed = ~r"[Rr]emoved\s+[Ii]n\s*"s
+cell_noprefix = _ ("(unprefixed)" / "(no prefix)" / "without prefix" /
+    "(without prefix)") _
 text_item = ~r"(?P<content>[^{<[]+)\s*"s
 
 text = (double_quoted_text / single_quoted_text / bare_text)
@@ -734,6 +737,10 @@ class PageVisitor(NodeVisitor):
 
     def visit_cell_removed(self, node, children):
         return {'type': 'removed', 'content': node.text, 'start': node.start,
+                'end': node.end}
+
+    def visit_cell_noprefix(self, node, children):
+        return {'type': 'noprefix', 'content': node.text, 'start': node.start,
                 'end': node.end}
 
     #
@@ -1695,6 +1702,8 @@ class PageVisitor(NodeVisitor):
                 assert not data['support'].get('id')
         elif item['type'] == 'removed':
             data['support']['support'] = 'no'
+        elif item['type'] == 'noprefix':
+            data['support']['support'] = 'yes'
         elif item['type'] in ('text', 'code'):
             out = self.item_to_html(item, 'support')
             if out:

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -224,13 +224,14 @@ tr_tags = tr_tag*
 #
 text_block = text_token+
 text_token = kumascript / cell_version / footnote_id / cell_removed /
-    cell_noprefix / text_item
+    cell_noprefix / cell_partial / text_item
 cell_version = ~r"(?P<version>\d+(\.\d+)*)"""
     r"""(\s+\((?P<eng_version>\d+(\.\d+)*)\))?\s*"s
 footnote_id = "[" ~r"(?P<content>\d+|\*+)" "]"
 cell_removed = ~r"[Rr]emoved\s+[Ii]n\s*"s
 cell_noprefix = _ ("(unprefixed)" / "(no prefix)" / "without prefix" /
     "(without prefix)") _
+cell_partial =  _ (", partial" / "(partial)") _
 text_item = ~r"(?P<content>[^{<[]+)\s*"s
 
 text = (double_quoted_text / single_quoted_text / bare_text)
@@ -741,6 +742,10 @@ class PageVisitor(NodeVisitor):
 
     def visit_cell_noprefix(self, node, children):
         return {'type': 'noprefix', 'content': node.text, 'start': node.start,
+                'end': node.end}
+
+    def visit_cell_partial(self, node, children):
+        return {'type': 'partial', 'content': node.text, 'start': node.start,
                 'end': node.end}
 
     #
@@ -1704,6 +1709,8 @@ class PageVisitor(NodeVisitor):
             data['support']['support'] = 'no'
         elif item['type'] == 'noprefix':
             data['support']['support'] = 'yes'
+        elif item['type'] == 'partial':
+            data['support']['support'] = 'partial'
         elif item['type'] in ('text', 'code'):
             out = self.item_to_html(item, 'support')
             if out:

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -296,6 +296,26 @@ Not part of any current spec, but it was in early drafts of
         self.assert_cell_version(
             "5.0 (532.5)", version="5.0", eng_version="532.5")
 
+    def assert_cell_no_prefix(self, text):
+        node = page_grammar['cell_noprefix'].parse(text)
+        self.assertEqual(text, node.text)
+
+    def test_unprefixed(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createBufferSource
+        self.assert_cell_no_prefix(' (unprefixed) ')
+
+    def test_noprefix(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/Navigator.vibrate
+        self.assert_cell_no_prefix(' (no prefix) ')
+
+    def test_without_prefix_naked(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line
+        self.assert_cell_no_prefix('without prefix')
+
+    def test_without_prefix(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager
+        self.assert_cell_no_prefix('(without prefix)')
+
 
 class ScrapeTestCase(TestCase):
     """Fixtures for scraping tests."""
@@ -1462,11 +1482,17 @@ present in early drafts of {{SpecName("CSS3 Animations")}}.
             'Removed in 32',
             [{'version': '32.0'}], [{'support': 'no'}])
 
-    def test_cell_to_support_unmatched_free_text(self):
+    def test_cell_to_support_unprefixed(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createBufferSource
         self.assert_cell_to_support(
             '32 (unprefixed)',
+            [{'version': '32.0'}], [{'support': 'yes'}])
+
+    def test_cell_to_support_unmatched_free_text(self):
+        self.assert_cell_to_support(
+            '32 (or earlier)',
             [{'version': '32.0'}], [{'support': 'yes'}],
-            issues=[('inline_text', 7, 19, {'text': '(unprefixed)'})])
+            issues=[('inline_text', 7, 19, {'text': '(or earlier)'})])
 
     def test_cell_to_support_code_block(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/order

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -316,6 +316,18 @@ Not part of any current spec, but it was in early drafts of
         # https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager
         self.assert_cell_no_prefix('(without prefix)')
 
+    def assert_cell_partial(self, text):
+        node = page_grammar['cell_partial'].parse(text)
+        self.assertEqual(text, node.text)
+
+    def test_comma_partial(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor
+        self.assert_cell_partial(', partial')
+
+    def test_parens_partal(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration
+        self.assert_cell_partial('(partial)')
+
 
 class ScrapeTestCase(TestCase):
     """Fixtures for scraping tests."""
@@ -1487,6 +1499,12 @@ present in early drafts of {{SpecName("CSS3 Animations")}}.
         self.assert_cell_to_support(
             '32 (unprefixed)',
             [{'version': '32.0'}], [{'support': 'yes'}])
+
+    def test_cell_to_support_partial(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor
+        self.assert_cell_to_support(
+            '10, partial',
+            [{'version': '10.0'}], [{'support': 'partial'}])
 
     def test_cell_to_support_unmatched_free_text(self):
         self.assert_cell_to_support(


### PR DESCRIPTION
*This is based on earlier PRs and can be rebased*

When parsing a compatability text segment, support these inline texts as describing the support:

```
(unprefixed)
(no prefix)
without prefix
(without prefix)
, partial
(partial)
```

After updating [browsercompat](https://browsercompat.herokuapp.com/importer/), the new issue counts are:

        Issue Slug         | Old Count | New Count
---------------------------|-----------|----------
**Total**                  |      6103 |      5804
inline_text                |      1896 |      1615
section_skipped            |      1604 |      1602
unexpected_attribute       |       488 |       475
spec2_converted            |       283 |       283
unknown_kumascript         |       272 |       270
skipped_h3                 |       262 |       262
unknown_version            |       221 |       221
specname_converted         |       193 |       193
halt_import                |       151 |       151
footnote_missing           |       106 |       106
specname_not_kumascript    |        98 |        98
missing_attribute          |        98 |        98
footnote_no_id             |        75 |        75
footnote_unused            |        59 |        59
unknown_browser            |        42 |        42
section_missed             |        40 |        40
spec_h2_id                 |        38 |        38
footnote_multiple          |        38 |        38
spec_h2_name               |        32 |        32
tag_dropped                |        22 |        22
unknown_spec               |        21 |        21
doc_parse_error            |        17 |        17
span_dropped               |        12 |        12
second_footnote            |        12 |        12
spec_mismatch              |        10 |        10
compatgeckodesktop_unknown |        10 |        10
footnote_feature           |         2 |         2
spec2_wrong_kumascript     |         1 |         0

Most of the issue count drop is due to ``inline_text`` dropping 281 issues, but it also includes some changes due to fixing MDN issues since yesterday.