### PR TITLE
bug 1078699 - GET /api/v1/view_features/by_slug

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,31 +3,31 @@
 # Documentation
 Pygments==2.0.2
 sphinx-rtd-theme==0.1.8
-alabaster==0.7.4
+alabaster==0.7.5
 Babel==1.3
 snowballstemmer==1.2.0
 Sphinx==1.3.1
 docutils==0.12
 
 # Multi-environment testing
-py==1.4.27
+py==1.4.28
 pluggy==0.3.0
-virtualenv==13.0.1
-tox==2.0.1
+virtualenv==13.0.3
+tox==2.0.2
 
 # PEP8, PEP257 and static analysis
-mccabe==0.3
+mccabe==0.3.1
 pep8==1.5.7  # rq.filter: <1.6,>=1.5.7
-pyflakes==0.8.1
+pyflakes==0.9.1
 flake8==2.4.1
 pep257==0.5.0
 flake8-docstrings==0.2.1.post1
 
 # MANIFEST.in checker
-check-manifest==0.24
+check-manifest==0.25
 
 # Package QA
-pyroma==1.8.1
+pyroma==1.8.2
 
 # For ./manage.py runserver_plus
 Werkzeug==0.10.4
@@ -35,7 +35,7 @@ Werkzeug==0.10.4
 # Better shell, debugger
 gnureadline==6.3.3
 ipython==3.1.0
-ipdb==0.8
+ipdb==0.8.1
 
 # Debugging
 sqlparse==0.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ django-mptt==0.7.4
 django-sortedm2m==0.10.0
 
 # Cached instances for Django REST Framework
-drf-cached-instances==0.3.0
+drf-cached-instances==0.3.1
 
 # CORS headers in middleware
 # django-cors-headers==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Jinja2==2.7.3
 jingo==0.7.1
 
 # Django REST Framework.
-djangorestframework==3.1.2
+djangorestframework==3.1.3
 Markdown==2.6.2
 django-filter==0.10.0
 
@@ -28,7 +28,7 @@ django-simple-history==1.6.1
 dj-database-url==0.3.0
 
 # Better test runner (included in settings)
-nose==1.3.6
+nose==1.3.7
 django-nose==1.4
 
 # Test Mocking, included in Python 3.3
@@ -38,7 +38,7 @@ mock==1.0.1
 gunicorn==19.3.0
 
 # Connect to PostgreSQL
-psycopg2==2.6
+psycopg2==2.6.1
 
 # Serve static files
 static3==0.6.1
@@ -60,7 +60,7 @@ kombu==3.0.26
 celery==3.1.18
 
 # Modified Preorder Tree Traversal
-django-mptt==0.7.3
+django-mptt==0.7.4
 
 # Sorted ManyToManyField
 django-sortedm2m==0.10.0
@@ -71,12 +71,12 @@ drf-cached-instances==0.3.0
 # CORS headers in middleware
 # django-cors-headers==1.1.0
 # Bug #50 (fixed by PR #51) prevents Firefox CORS
-git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
+git+git://github.com/ottoyiu/django-cors-headers@1e7bf86#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
 # parsimonious==0.6.2
 # TravisCI is now using ascii as system encoding, breaking setup.py
-git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
+git+git://github.com/erikrose/parsimonious@20863d86a#egg=parsimonious
 
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps = {[base]deps}
 [testenv:flake8]
 deps =
     {[base]deps}
-    flake8==2.4.0
+    flake8==2.4.1
     flake8-docstrings==0.2.1.post1
 commands = flake8
 

--- a/webplatformcompat/tests/test_view_serializers.py
+++ b/webplatformcompat/tests/test_view_serializers.py
@@ -1718,6 +1718,24 @@ multipage/sections.html#the-address-element">
         self.assertDataEqual(expected, response.content.decode('utf-8'))
         self.assertContains(response, expected, html=True)
 
+    def test_slug(self):
+        feature = self.create(Feature, slug='feature')
+        browser = self.create(Browser, slug='chrome', name={'en': 'Browser'})
+        version = self.create(Version, browser=browser, status='current')
+        self.create(Support, version=version, feature=feature)
+        self.changeset.closed = True
+        self.changeset.save()
+
+        url = reverse('viewfeatures-detail', kwargs={'pk': 'feature'})
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(feature.id, response.data['id'])
+
+    def test_slug_not_found(self):
+        url = reverse('viewfeatures-detail', kwargs={'pk': 'feature'})
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
+
 
 class TestViewFeatureUpdates(APITestCase):
     """Test PUT to a ViewFeature detail"""

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib.auth.models import User
+from django.http import Http404
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.renderers import BrowsableAPIRenderer
@@ -203,3 +204,17 @@ class ViewFeaturesViewSet(UpdateOnlyModelViewSet):
             return ViewFeatureListSerializer
         else:
             return super(ViewFeaturesViewSet, self).get_serializer_class()
+
+    def get_object_or_404(self, queryset, *filter_args, **filter_kwargs):
+        """The feature can be accessed by primary key or by feature slug."""
+        pk_or_slug = filter_kwargs['pk']
+        try:
+            pk = int(pk_or_slug)
+        except ValueError:
+            try:
+                pk = Feature.objects.only('pk').get(slug=pk_or_slug).pk
+            except queryset.model.DoesNotExist:
+                raise Http404(
+                    'No %s matches the given query.' % queryset.model)
+        return super(ViewFeaturesViewSet, self).get_object_or_404(
+            queryset, pk=pk)


### PR DESCRIPTION
*This PR builds on previous PRs, and can be rebased*

The ``view_feature`` endpoint is used to get the Feature and related data for constructing a compatibility table.  In addition to fetching by feature id:

http://browsercompat.herokuapp.com/api/v1/view_features/730

this code adds the ability to fetch by feature slug:

http://browsercompat.herokuapp.com/api/v1/view_features/web-css-display

This may be a better target for a KumaScript macro, such as  ``{{CompatTable('web-css-display')}}`` vs ``{{CompatTable(730)}}``.

[bug 1078699](https://bugzilla.mozilla.org/show_bug.cgi?id=1078699) includes all resources being available by appropriate slugs (username for users, etc.).  This is trial code for that design change, so I'm not closing the bug.